### PR TITLE
fix: hidden folders are not touched when updating links

### DIFF
--- a/utils/update-links.go
+++ b/utils/update-links.go
@@ -38,12 +38,8 @@ func UpdateLinksInVault(dirPath string, oldNoteName string, newNoteName string) 
 			return err
 		}
 
-		// Skip hidden directories
-		if info.IsDir() && info.Name()[0] == '.' {
-			return filepath.SkipDir
-		}
-
-		if info.IsDir() {
+		// Skip hidden directories and non-markdown files
+		if shouldSkipDirectoryOrFile(info) {
 			return nil
 		}
 
@@ -67,4 +63,16 @@ func UpdateLinksInVault(dirPath string, oldNoteName string, newNoteName string) 
 
 	fmt.Print("Update links inside: ", dirPath, " from ", oldNoteName, " to ", newNoteName)
 
+}
+
+func shouldSkipDirectoryOrFile(info os.FileInfo) bool {
+	isDirectory := info.IsDir()
+	isHidden := info.Name()[0] == '.'
+	isNonMarkdownFile := filepath.Ext(info.Name()) != ".md"
+
+	if isDirectory || isHidden || isNonMarkdownFile {
+		return true
+	}
+
+	return false
 }

--- a/utils/update-links.go
+++ b/utils/update-links.go
@@ -37,9 +37,16 @@ func UpdateLinksInVault(dirPath string, oldNoteName string, newNoteName string) 
 		if err != nil {
 			return err
 		}
+
+		// Skip hidden directories
+		if info.IsDir() && info.Name()[0] == '.' {
+			return filepath.SkipDir
+		}
+
 		if info.IsDir() {
 			return nil
 		}
+
 		content, err := ioutil.ReadFile(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

Bug fix for https://github.com/Yakitrak/obsidian-cli/issues/10

Hidden folders such as `.git` or `.obisidian` are not read when traversing directories to update note links.

