### PR TITLE
feat: Add open flag to create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ obs search "{search-text}" --vault "{vault-name}"
 
 ### Create / Update Note
 
-Creates note (can also be a path with name) in vault. By default if the note exists, it will create another note but passing `--overwrite` or `--append` can be used to edit the named note.
+Creates note (can also be a path with name) in vault. By default, if the note exists, it will create another note but passing `--overwrite` or `--append` can be used to edit the named note.
 
 ```bash
 # Creates empty note in default obsidian and opens it
@@ -99,6 +99,9 @@ obs create "{note-name}" --content "abcde" --overwrite
 
 # Creates note in default obsidian with content - append existing note
 obs create "{note-name}" --content "abcde" --append
+
+# Creates note and opens it
+obs create "{note-name}" --content "abcde" --open
 
 ```
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -24,6 +24,7 @@ var createNoteCmd = &cobra.Command{
 			Content:         content,
 			ShouldAppend:    shouldAppend,
 			ShouldOverwrite: shouldOverwrite,
+			ShouldOpen:      shouldOpen,
 		}
 		err := actions.CreateNote(&vault, &uri, params)
 		if err != nil {
@@ -34,6 +35,7 @@ var createNoteCmd = &cobra.Command{
 
 func init() {
 	createNoteCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name")
+	createNoteCmd.Flags().BoolVarP(&shouldOpen, "open", "", false, "open created note")
 	createNoteCmd.Flags().StringVarP(&content, "content", "c", "", "text to add to note")
 	createNoteCmd.Flags().BoolVarP(&shouldAppend, "append", "a", false, "append to note")
 	createNoteCmd.Flags().BoolVarP(&shouldOverwrite, "overwrite", "o", false, "overwrite note")

--- a/pkg/actions/create.go
+++ b/pkg/actions/create.go
@@ -10,6 +10,7 @@ type CreateParams struct {
 	ShouldAppend    bool
 	ShouldOverwrite bool
 	Content         string
+	ShouldOpen      bool
 }
 
 func CreateNote(vault obsidian.VaultManager, uri obsidian.UriManager, params CreateParams) error {
@@ -24,11 +25,13 @@ func CreateNote(vault obsidian.VaultManager, uri obsidian.UriManager, params Cre
 		"overwrite": strconv.FormatBool(params.ShouldOverwrite),
 		"content":   params.Content,
 		"file":      params.NoteName,
+		"silent":    strconv.FormatBool(!params.ShouldOpen),
 	})
 
 	err = uri.Execute(obsidianUri)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/pkg/actions/create_test.go
+++ b/pkg/actions/create_test.go
@@ -47,5 +47,3 @@ func TestCreateNote(t *testing.T) {
 		assert.Equal(t, err, uri.ExecuteErr)
 	})
 }
-
-// todo test for create note with open flag

--- a/pkg/actions/create_test.go
+++ b/pkg/actions/create_test.go
@@ -47,3 +47,5 @@ func TestCreateNote(t *testing.T) {
 		assert.Equal(t, err, uri.ExecuteErr)
 	})
 }
+
+// todo test for create note with open flag


### PR DESCRIPTION
# Add open flag to create command

**Description**
Adds `open` flag to create command so the new note can be opened.


**Motivation and Context**
Adds consistency to match the same behaviour as `move` command where by default the note is not opened but can be done so by the flag. 

**Checklist:**
- [ ] I have written unit tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.