### PR TITLE
Removed `brew tap <Homebrew tap>` because Homebrew taps the tap when you run `brew install <tap author>/<tap name>/<package>

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ scoop install obsidian-cli
 You will need to have [Homebrew](https://brew.sh/) installed.
 
 ```Bash
-brew tap yakitrak/yakitrak
-```
-
-```Bash
 brew install yakitrak/yakitrak/obsidian-cli
 ```
 


### PR DESCRIPTION
# Pull Request Title

**Description**
I removed `brew tap <Homebrew tap>` because Homebrew taps the tap when you run `brew install <tap author>/<tap name>/<package>

**Motivation and Context**
Because that command is not required

**Checklist:**
- [ ] I have written unit tests for my changes. (it doesn't need any tests)
- [x ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed. (it doesn't need any tests)