### PR TITLE
fix: prevent unnecessary file timestamp updates

### DIFF
--- a/pkg/obsidian/note.go
+++ b/pkg/obsidian/note.go
@@ -1,6 +1,7 @@
 package obsidian
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -94,7 +95,7 @@ func (m *Note) UpdateLinks(vaultPath string, oldNoteName string, newNoteName str
 			return nil
 		}
 
-		content, err := os.ReadFile(path)
+		originalContent, err := os.ReadFile(path)
 		if err != nil {
 			return errors.New(VaultReadError)
 		}
@@ -102,13 +103,17 @@ func (m *Note) UpdateLinks(vaultPath string, oldNoteName string, newNoteName str
 		oldNoteLinkTexts := GenerateNoteLinkTexts(oldNoteName)
 		newNoteLinkTexts := GenerateNoteLinkTexts(newNoteName)
 
-		content = ReplaceContent(content, map[string]string{
+		updatedContent := ReplaceContent(originalContent, map[string]string{
 			oldNoteLinkTexts[0]: newNoteLinkTexts[0],
 			oldNoteLinkTexts[1]: newNoteLinkTexts[1],
 			oldNoteLinkTexts[2]: newNoteLinkTexts[2],
 		})
 
-		err = os.WriteFile(path, content, info.Mode())
+		if bytes.Equal(originalContent, updatedContent) {
+			return nil
+		}
+
+		err = os.WriteFile(path, updatedContent, info.Mode())
 		if err != nil {
 			return errors.New(VaultWriteError)
 		}


### PR DESCRIPTION
Only write files when content actually changes to prevent unnecessary modification time updates and reduce I/O operations.

# Pull Request Title
Write file only when the contents have changed

**Description**
Compare the contents of the file before the ReplaceAll operation to after and if the contents are the same then don't write the file back to disk

**Motivation and Context**
File modification timestamps are no longer changed unless the file is written.  File will not be written unless the file has changed.

My motivation is that I use my markdown file timestamps to know whats been updated lately.  I don't want all my markdown file timestamps updated unless the content has really changed.

**Checklist:**
- [x] I have written unit tests for my changes.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.