### PR TITLE
chore: choose a formatter to make diffs clean

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+formatters:
+  enable:
+    - gofumpt
+  settings:
+    gofumpt:
+      extra-rules: true

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,22 @@ build-all:
 	GOOS=linux GOARCH=amd64 go build -o bin/linux/${BINARY_NAME}
 	GOOS=windows GOARCH=amd64 go build -o bin/windows/${BINARY_NAME}.exe
 
+fmt:
+	docker run --rm \
+	  -v $$(pwd):/app \
+	  -v golangci-cache:/root/.cache \
+	  -w /app \
+	  golangci/golangci-lint:v2.5.0 \
+	  golangci-lint fmt
+
 clean-all:
 	go clean
 	rm bin/darwin/${BINARY_NAME}
 	rm bin/linux/${BINARY_NAME}
 	rm bin/windows/${BINARY_NAME}.exe
+
+clean-cache:
+	docker volume rm golangci-cache
 
 test:
 	go test ./...

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,37 +1,40 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/spf13/cobra"
-	"log"
 )
 
-var shouldAppend bool
-var shouldOverwrite bool
-var content string
-var createNoteCmd = &cobra.Command{
-	Use:     "create",
-	Aliases: []string{"c"},
-	Short:   "Creates note in vault",
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		vault := obsidian.Vault{Name: vaultName}
-		uri := obsidian.Uri{}
-		noteName := args[0]
-		params := actions.CreateParams{
-			NoteName:        noteName,
-			Content:         content,
-			ShouldAppend:    shouldAppend,
-			ShouldOverwrite: shouldOverwrite,
-			ShouldOpen:      shouldOpen,
-		}
-		err := actions.CreateNote(&vault, &uri, params)
-		if err != nil {
-			log.Fatal(err)
-		}
-	},
-}
+var (
+	shouldAppend    bool
+	shouldOverwrite bool
+	content         string
+	createNoteCmd   = &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"c"},
+		Short:   "Creates note in vault",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			vault := obsidian.Vault{Name: vaultName}
+			uri := obsidian.Uri{}
+			noteName := args[0]
+			params := actions.CreateParams{
+				NoteName:        noteName,
+				Content:         content,
+				ShouldAppend:    shouldAppend,
+				ShouldOverwrite: shouldOverwrite,
+				ShouldOpen:      shouldOpen,
+			}
+			err := actions.CreateNote(&vault, &uri, params)
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+)
 
 func init() {
 	createNoteCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name")

--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 var DailyCmd = &cobra.Command{

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
-	"log"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -1,37 +1,39 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
-	"log"
 
 	"github.com/spf13/cobra"
 )
 
-var shouldOpen bool
-var moveCmd = &cobra.Command{
-	Use:     "move",
-	Aliases: []string{"m"},
-	Short:   "Move or rename note in vault and updated corresponding links",
-	Args:    cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
-		currentName := args[0]
-		newName := args[1]
-		vault := obsidian.Vault{Name: vaultName}
-		note := obsidian.Note{}
-		uri := obsidian.Uri{}
-		params := actions.MoveParams{
-			CurrentNoteName: currentName,
-			NewNoteName:     newName,
-			ShouldOpen:      shouldOpen,
-		}
-		err := actions.MoveNote(&vault, &note, &uri, params)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-	},
-}
+var (
+	shouldOpen bool
+	moveCmd    = &cobra.Command{
+		Use:     "move",
+		Aliases: []string{"m"},
+		Short:   "Move or rename note in vault and updated corresponding links",
+		Args:    cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			currentName := args[0]
+			newName := args[1]
+			vault := obsidian.Vault{Name: vaultName}
+			note := obsidian.Note{}
+			uri := obsidian.Uri{}
+			params := actions.MoveParams{
+				CurrentNoteName: currentName,
+				NewNoteName:     newName,
+				ShouldOpen:      shouldOpen,
+			}
+			err := actions.MoveNote(&vault, &note, &uri, params)
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+)
 
 func init() {
 	moveCmd.Flags().BoolVarP(&shouldOpen, "open", "o", false, "open new note")

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,29 +1,32 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/spf13/cobra"
-	"log"
 )
 
-var vaultName string
-var OpenVaultCmd = &cobra.Command{
-	Use:     "open",
-	Aliases: []string{"o"},
-	Short:   "Opens note in vault by note name",
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		vault := obsidian.Vault{Name: vaultName}
-		uri := obsidian.Uri{}
-		noteName := args[0]
-		params := actions.OpenParams{NoteName: noteName}
-		err := actions.OpenNote(&vault, &uri, params)
-		if err != nil {
-			log.Fatal(err)
-		}
-	},
-}
+var (
+	vaultName    string
+	OpenVaultCmd = &cobra.Command{
+		Use:     "open",
+		Aliases: []string{"o"},
+		Short:   "Opens note in vault by note name",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			vault := obsidian.Vault{Name: vaultName}
+			uri := obsidian.Uri{}
+			noteName := args[0]
+			params := actions.OpenParams{NoteName: noteName}
+			err := actions.OpenNote(&vault, &uri, params)
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+)
 
 func init() {
 	OpenVaultCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name (not required if default is set)")

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -2,33 +2,36 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
-	"log"
 
 	"github.com/spf13/cobra"
 )
 
-var shouldRenderMarkdown bool
-var printCmd = &cobra.Command{
-	Use:     "print",
-	Aliases: []string{"p"},
-	Short:   "Print contents of note",
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		noteName := args[0]
-		vault := obsidian.Vault{Name: vaultName}
-		note := obsidian.Note{}
-		params := actions.PrintParams{
-			NoteName: noteName,
-		}
-		contents, err := actions.PrintNote(&vault, &note, params)
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Println(contents)
-	},
-}
+var (
+	shouldRenderMarkdown bool
+	printCmd             = &cobra.Command{
+		Use:     "print",
+		Aliases: []string{"p"},
+		Short:   "Print contents of note",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			noteName := args[0]
+			vault := obsidian.Vault{Name: vaultName}
+			note := obsidian.Note{}
+			params := actions.PrintParams{
+				NoteName: noteName,
+			}
+			contents, err := actions.PrintNote(&vault, &note, params)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Println(contents)
+		},
+	}
+)
 
 func init() {
 	printCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name")

--- a/cmd/print_default.go
+++ b/cmd/print_default.go
@@ -8,32 +8,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var printPathOnly bool
-var printDefaultCmd = &cobra.Command{
-	Use:     "print-default",
-	Aliases: []string{"pd"},
-	Short:   "prints default vault name and path",
-	Args:    cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		vault := obsidian.Vault{}
-		name, err := vault.DefaultName()
-		if err != nil {
-			log.Fatal(err)
-		}
-		path, err := vault.Path()
-		if err != nil {
-			log.Fatal(err)
-		}
+var (
+	printPathOnly   bool
+	printDefaultCmd = &cobra.Command{
+		Use:     "print-default",
+		Aliases: []string{"pd"},
+		Short:   "prints default vault name and path",
+		Args:    cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			vault := obsidian.Vault{}
+			name, err := vault.DefaultName()
+			if err != nil {
+				log.Fatal(err)
+			}
+			path, err := vault.Path()
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		if printPathOnly {
-			fmt.Print(path)
-			return
-		}
+			if printPathOnly {
+				fmt.Print(path)
+				return
+			}
 
-		fmt.Println("Default vault name: ", name)
-		fmt.Println("Default vault path: ", path)
-	},
-}
+			fmt.Println("Default vault name: ", name)
+			fmt.Println("Default vault path: ", path)
+		},
+	}
+)
 
 func init() {
 	printDefaultCmd.Flags().BoolVar(&printPathOnly, "path-only", false, "print only the vault path")

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
-	"log"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/set_default.go
+++ b/cmd/set_default.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 var setDefaultCmd = &cobra.Command{
@@ -25,7 +26,6 @@ var setDefaultCmd = &cobra.Command{
 		}
 		fmt.Println("Default vault set to: ", name)
 		fmt.Println("Default vault path set to: ", path)
-
 	},
 }
 

--- a/pkg/actions/create.go
+++ b/pkg/actions/create.go
@@ -1,9 +1,10 @@
 package actions
 
 import (
-	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"strconv"
 	"strings"
+
+	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 )
 
 type CreateParams struct {

--- a/pkg/actions/create_test.go
+++ b/pkg/actions/create_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCreateNote(t *testing.T) {

--- a/pkg/actions/daily_test.go
+++ b/pkg/actions/daily_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDailyNote(t *testing.T) {

--- a/pkg/actions/delete.go
+++ b/pkg/actions/delete.go
@@ -1,8 +1,9 @@
 package actions
 
 import (
-	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"path/filepath"
+
+	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 )
 
 type DeleteParams struct {

--- a/pkg/actions/delete_test.go
+++ b/pkg/actions/delete_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDeleteNote(t *testing.T) {

--- a/pkg/actions/move.go
+++ b/pkg/actions/move.go
@@ -1,8 +1,9 @@
 package actions
 
 import (
-	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"path/filepath"
+
+	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 )
 
 type MoveParams struct {

--- a/pkg/actions/move_test.go
+++ b/pkg/actions/move_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMoveNote(t *testing.T) {

--- a/pkg/actions/open_test.go
+++ b/pkg/actions/open_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestOpenNote(t *testing.T) {

--- a/pkg/actions/print_test.go
+++ b/pkg/actions/print_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/actions"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestPrintNote(t *testing.T) {

--- a/pkg/actions/search.go
+++ b/pkg/actions/search.go
@@ -23,7 +23,6 @@ func SearchNotes(vault obsidian.VaultManager, note obsidian.NoteManager, uri obs
 	index, err := fuzzyFinder.Find(notes, func(i int) string {
 		return notes[i]
 	})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/config/cli_path.go
+++ b/pkg/config/cli_path.go
@@ -8,7 +8,7 @@ import (
 
 var UserConfigDirectory = os.UserConfigDir
 
-func CliPath() (cliConfigDir string, cliConfigFile string, err error) {
+func CliPath() (cliConfigDir, cliConfigFile string, err error) {
 	userConfigDir, err := UserConfigDirectory()
 	if err != nil {
 		return "", "", errors.New(UserConfigDirectoryNotFoundErrorMessage)

--- a/pkg/config/cli_path_test.go
+++ b/pkg/config/cli_path_test.go
@@ -2,9 +2,10 @@ package config_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/config"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestConfigCliPath(t *testing.T) {
@@ -36,5 +37,4 @@ func TestConfigCliPath(t *testing.T) {
 		assert.Equal(t, "", obsConfigDir)
 		assert.Equal(t, "", obsConfigFile)
 	})
-
 }

--- a/pkg/config/obsidian_path_test.go
+++ b/pkg/config/obsidian_path_test.go
@@ -2,9 +2,10 @@ package config_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/config"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestConfigObsidianPath(t *testing.T) {

--- a/pkg/obsidian/fuzzyfinder.go
+++ b/pkg/obsidian/fuzzyfinder.go
@@ -2,6 +2,7 @@ package obsidian
 
 import (
 	"errors"
+
 	"github.com/ktr0731/go-fuzzyfinder"
 )
 

--- a/pkg/obsidian/note.go
+++ b/pkg/obsidian/note.go
@@ -11,8 +11,7 @@ import (
 	"strings"
 )
 
-type Note struct {
-}
+type Note struct{}
 
 type NoteMatch struct {
 	FilePath   string
@@ -29,12 +28,11 @@ type NoteManager interface {
 	SearchNotesWithSnippets(string, string) ([]NoteMatch, error)
 }
 
-func (m *Note) Move(originalPath string, newPath string) error {
+func (m *Note) Move(originalPath, newPath string) error {
 	o := AddMdSuffix(originalPath)
 	n := AddMdSuffix(newPath)
 
 	err := os.Rename(o, n)
-
 	if err != nil {
 		return errors.New(NoteDoesNotExistError)
 	}
@@ -46,6 +44,7 @@ to %s`, o, n)
 	fmt.Println(message)
 	return nil
 }
+
 func (m *Note) Delete(path string) error {
 	note := AddMdSuffix(path)
 	err := os.Remove(note)
@@ -56,7 +55,7 @@ func (m *Note) Delete(path string) error {
 	return nil
 }
 
-func (m *Note) GetContents(vaultPath string, noteName string) (string, error) {
+func (m *Note) GetContents(vaultPath, noteName string) (string, error) {
 	note := AddMdSuffix(noteName)
 
 	var notePath string
@@ -101,7 +100,7 @@ func (m *Note) GetContents(vaultPath string, noteName string) (string, error) {
 	return string(content), nil
 }
 
-func (m *Note) UpdateLinks(vaultPath string, oldNoteName string, newNoteName string) error {
+func (m *Note) UpdateLinks(vaultPath, oldNoteName, newNoteName string) error {
 	err := filepath.Walk(vaultPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return errors.New(VaultAccessError)
@@ -162,7 +161,7 @@ func (m *Note) GetNotesList(vaultPath string) ([]string, error) {
 	return notes, nil
 }
 
-func (m *Note) SearchNotesWithSnippets(vaultPath string, query string) ([]NoteMatch, error) {
+func (m *Note) SearchNotesWithSnippets(vaultPath, query string) ([]NoteMatch, error) {
 	var matches []NoteMatch
 	queryLower := strings.ToLower(query)
 
@@ -232,7 +231,6 @@ func (m *Note) SearchNotesWithSnippets(vaultPath string, query string) ([]NoteMa
 		}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/obsidian/note_test.go
+++ b/pkg/obsidian/note_test.go
@@ -27,7 +27,7 @@ func TestDeleteNote(t *testing.T) {
 			notePathToCreate := filepath.Join(tempDir, test.noteToCreate)
 			notePath := filepath.Join(tempDir, test.noteArg)
 
-			err := os.WriteFile(notePathToCreate, []byte(""), 0644)
+			err := os.WriteFile(notePathToCreate, []byte(""), 0o644)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -36,7 +36,6 @@ func TestDeleteNote(t *testing.T) {
 			err = noteManager.Delete(notePath)
 			// Assert
 			assert.Equal(t, nil, err, "Expected no error while deleting note")
-
 		})
 	}
 
@@ -47,9 +46,9 @@ func TestDeleteNote(t *testing.T) {
 		err := noteManager.Delete("non-existent-note")
 		// Assert
 		assert.Equal(t, obsidian.NoteDoesNotExistError, err.Error(), "Expected error while deleting non-existent note")
-
 	})
 }
+
 func TestNote_GetContents(t *testing.T) {
 	tests := []struct {
 		testName           string
@@ -67,12 +66,12 @@ func TestNote_GetContents(t *testing.T) {
 			notePath := filepath.Join(tempDir, vaultPath, test.noteToCreate)
 			fileContents := "Example file contents here"
 
-			err := os.MkdirAll(filepath.Join(tempDir, vaultPath), 0755)
+			err := os.MkdirAll(filepath.Join(tempDir, vaultPath), 0o755)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = os.WriteFile(notePath, []byte(fileContents), 0644)
+			err = os.WriteFile(notePath, []byte(fileContents), 0o644)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -97,12 +96,12 @@ func TestNote_GetContents(t *testing.T) {
 		actualNotePath := filepath.Join(tempDir, vaultPath, fullNotePath)
 		fileContents := "Cookie recipe content here"
 
-		err := os.MkdirAll(filepath.Dir(actualNotePath), 0755)
+		err := os.MkdirAll(filepath.Dir(actualNotePath), 0o755)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = os.WriteFile(actualNotePath, []byte(fileContents), 0644)
+		err = os.WriteFile(actualNotePath, []byte(fileContents), 0o644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -131,7 +130,6 @@ func TestNote_GetContents(t *testing.T) {
 		// Assert
 		assert.Equal(t, obsidian.NoteDoesNotExistError, err.Error(), "Expected error while deleting non-existent note")
 		assert.Equal(t, contents, "")
-
 	})
 }
 
@@ -159,7 +157,7 @@ func TestMoveNote(t *testing.T) {
 			existingNoteFullPathToCreate := filepath.Join(tempDir, test.existingNotePathToCreate)
 			expectedNewPath := filepath.Join(tempDir, test.expectedNotePath)
 
-			err := os.WriteFile(existingNoteFullPathToCreate, []byte(originalContent), 0644)
+			err := os.WriteFile(existingNoteFullPathToCreate, []byte(originalContent), 0o644)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -189,7 +187,6 @@ func TestMoveNote(t *testing.T) {
 				t.Fatal(err)
 			}
 			assert.Equal(t, string(newContent), originalContent, "New file content is %q, expected %q", string(newContent), originalContent)
-
 		})
 	}
 
@@ -214,17 +211,18 @@ func createTmpDirAndFiles(t *testing.T, perm os.FileMode, files []string, conten
 		}
 	}
 	// create other non markdown files
-	err := os.WriteFile(filepath.Join(tmpDir, "file4.txt"), []byte("This is a test file"), 0644)
+	err := os.WriteFile(filepath.Join(tmpDir, "file4.txt"), []byte("This is a test file"), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 	// create hidden directory
-	err = os.Mkdir(filepath.Join(tmpDir, ".hidden"), 0644)
+	err = os.Mkdir(filepath.Join(tmpDir, ".hidden"), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create hidden directory: %v", err)
 	}
 	return tmpDir
 }
+
 func TestUpdateNoteLinks(t *testing.T) {
 	oldNoteName := "oldNote"
 	newNoteName := "newNote"
@@ -233,7 +231,7 @@ func TestUpdateNoteLinks(t *testing.T) {
 
 	t.Run("Update note links successfully", func(t *testing.T) {
 		// Arrange
-		tmpDir := createTmpDirAndFiles(t, 0644, testFiles, content)
+		tmpDir := createTmpDirAndFiles(t, 0o644, testFiles, content)
 
 		noteManager := obsidian.Note{}
 
@@ -264,7 +262,7 @@ func TestUpdateNoteLinks(t *testing.T) {
 
 	t.Run("Error reading files in vault", func(t *testing.T) {
 		// Arrange
-		tmpDir := createTmpDirAndFiles(t, 0000, testFiles, content)
+		tmpDir := createTmpDirAndFiles(t, 0o000, testFiles, content)
 		noteManager := obsidian.Note{}
 		// Act
 		err := noteManager.UpdateLinks(tmpDir, "oldNote", "newNote")
@@ -274,7 +272,7 @@ func TestUpdateNoteLinks(t *testing.T) {
 
 	t.Run("Error on writing to files in vault", func(t *testing.T) {
 		// Arrange
-		tmpDir := createTmpDirAndFiles(t, 0444, testFiles, content)
+		tmpDir := createTmpDirAndFiles(t, 0o444, testFiles, content)
 		noteManager := obsidian.Note{}
 		// Act
 		err := noteManager.UpdateLinks(tmpDir, "oldNote", "newNote")
@@ -295,19 +293,19 @@ func TestUpdateLinks_PreservesTimestamps(t *testing.T) {
 		fileWithOtherLinks := filepath.Join(tmpDir, "other_links.md")
 
 		// File that contains the old note name - should be updated
-		err := os.WriteFile(fileWithLinks, []byte("Content with [[OldNote]] reference"), 0644)
+		err := os.WriteFile(fileWithLinks, []byte("Content with [[OldNote]] reference"), 0o644)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// File with no relevant links - should NOT be updated
-		err = os.WriteFile(fileWithoutLinks, []byte("Content with no links"), 0644)
+		err = os.WriteFile(fileWithoutLinks, []byte("Content with no links"), 0o644)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// File with other links - should NOT be updated
-		err = os.WriteFile(fileWithOtherLinks, []byte("Content with [[SomeOtherNote]] reference"), 0644)
+		err = os.WriteFile(fileWithOtherLinks, []byte("Content with [[SomeOtherNote]] reference"), 0o644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -362,7 +360,7 @@ func TestNote_GetNotesList(t *testing.T) {
 		// Arrange
 		testFiles := []string{"file1.md", "file2.md", "file3.md"}
 		content := []byte("This is a test note")
-		tmpDir := createTmpDirAndFiles(t, 0644, testFiles, content)
+		tmpDir := createTmpDirAndFiles(t, 0o644, testFiles, content)
 
 		noteManager := obsidian.Note{}
 
@@ -389,7 +387,7 @@ func TestNote_GetNotesList(t *testing.T) {
 
 	t.Run("Vault directory with non-Markdown files", func(t *testing.T) {
 		// Arrange
-		tmpDir := createTmpDirAndFiles(t, 0644, []string{"file1.txt", "file2.jpg"}, []byte("Non-markdown content"))
+		tmpDir := createTmpDirAndFiles(t, 0o644, []string{"file1.txt", "file2.jpg"}, []byte("Non-markdown content"))
 		noteManager := obsidian.Note{}
 
 		// Act
@@ -408,7 +406,7 @@ func TestSearchNotesWithSnippets(t *testing.T) {
 		vaultPath := "vault-folder"
 		fullVaultPath := filepath.Join(tempDir, vaultPath)
 
-		err := os.MkdirAll(fullVaultPath, 0755)
+		err := os.MkdirAll(fullVaultPath, 0o755)
 		assert.NoError(t, err)
 
 		// Create test files
@@ -419,7 +417,7 @@ func TestSearchNotesWithSnippets(t *testing.T) {
 		}
 
 		for filename, content := range testFiles {
-			err = os.WriteFile(filepath.Join(fullVaultPath, filename), []byte(content), 0644)
+			err = os.WriteFile(filepath.Join(fullVaultPath, filename), []byte(content), 0o644)
 			assert.NoError(t, err)
 		}
 
@@ -449,10 +447,10 @@ func TestSearchNotesWithSnippets(t *testing.T) {
 		vaultPath := "vault-folder"
 		fullVaultPath := filepath.Join(tempDir, vaultPath)
 
-		err := os.MkdirAll(fullVaultPath, 0755)
+		err := os.MkdirAll(fullVaultPath, 0o755)
 		assert.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(fullVaultPath, "test-note.md"), []byte("Some content"), 0644)
+		err = os.WriteFile(filepath.Join(fullVaultPath, "test-note.md"), []byte("Some content"), 0o644)
 		assert.NoError(t, err)
 
 		// Act
@@ -473,11 +471,11 @@ func TestSearchNotesWithSnippets(t *testing.T) {
 		vaultPath := "vault-folder"
 		fullVaultPath := filepath.Join(tempDir, vaultPath)
 
-		err := os.MkdirAll(fullVaultPath, 0755)
+		err := os.MkdirAll(fullVaultPath, 0o755)
 		assert.NoError(t, err)
 
 		// Create a file that matches both filename and content
-		err = os.WriteFile(filepath.Join(fullVaultPath, "test-note.md"), []byte("This contains test content\nAnother line"), 0644)
+		err = os.WriteFile(filepath.Join(fullVaultPath, "test-note.md"), []byte("This contains test content\nAnother line"), 0o644)
 		assert.NoError(t, err)
 
 		// Act
@@ -499,10 +497,10 @@ func TestSearchNotesWithSnippets(t *testing.T) {
 		vaultPath := "vault-folder"
 		fullVaultPath := filepath.Join(tempDir, vaultPath)
 
-		err := os.MkdirAll(fullVaultPath, 0755)
+		err := os.MkdirAll(fullVaultPath, 0o755)
 		assert.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(fullVaultPath, "note.md"), []byte("Some content"), 0644)
+		err = os.WriteFile(filepath.Join(fullVaultPath, "note.md"), []byte("Some content"), 0o644)
 		assert.NoError(t, err)
 
 		// Act
@@ -520,11 +518,11 @@ func TestSearchNotesWithSnippets(t *testing.T) {
 		vaultPath := "vault-folder"
 		fullVaultPath := filepath.Join(tempDir, vaultPath)
 
-		err := os.MkdirAll(fullVaultPath, 0755)
+		err := os.MkdirAll(fullVaultPath, 0o755)
 		assert.NoError(t, err)
 
 		longLine := "This is a very long line that contains the word test and should be truncated because it exceeds the maximum length limit"
-		err = os.WriteFile(filepath.Join(fullVaultPath, "note.md"), []byte(longLine), 0644)
+		err = os.WriteFile(filepath.Join(fullVaultPath, "note.md"), []byte(longLine), 0o644)
 		assert.NoError(t, err)
 
 		// Act

--- a/pkg/obsidian/uri.go
+++ b/pkg/obsidian/uri.go
@@ -2,12 +2,12 @@ package obsidian
 
 import (
 	"errors"
-	"github.com/skratchdot/open-golang/open"
 	"net/url"
+
+	"github.com/skratchdot/open-golang/open"
 )
 
-type Uri struct {
-}
+type Uri struct{}
 
 type UriManager interface {
 	Construct(baseUri string, params map[string]string) string
@@ -31,11 +31,10 @@ func (u *Uri) Construct(baseUri string, params map[string]string) string {
 var Run = open.Run
 
 func (u *Uri) Execute(uri string) error {
-	//fmt.Println("Opening URI: ", uri)
+	// fmt.Println("Opening URI: ", uri)
 	err := Run(uri)
 	if err != nil {
 		return errors.New(ExecuteUriError)
-
 	}
 	return nil
 }

--- a/pkg/obsidian/uri_test.go
+++ b/pkg/obsidian/uri_test.go
@@ -3,14 +3,15 @@ package obsidian_test
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestUriConstruct(t *testing.T) {
 	baseUri := "base-uri"
-	var tests = []struct {
+	tests := []struct {
 		testName string
 		in       map[string]string
 		want     string
@@ -61,5 +62,4 @@ func TestUriExecute(t *testing.T) {
 		// Assert
 		assert.Equal(t, obsidian.ExecuteUriError, err.Error())
 	})
-
 }

--- a/pkg/obsidian/utils_test.go
+++ b/pkg/obsidian/utils_test.go
@@ -1,11 +1,12 @@
 package obsidian_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestAddMdSuffix(t *testing.T) {
@@ -49,7 +50,7 @@ func TestRemoveMdSuffix(t *testing.T) {
 }
 
 func TestGenerateNoteLinkTexts(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		testName string
 		noteName string
 		want     [3]string
@@ -89,7 +90,6 @@ func TestReplaceContent(t *testing.T) {
 			assert.Equal(t, string(test.want), string(got))
 		})
 	}
-
 }
 
 func TestShouldSkipDirectoryOrFile(t *testing.T) {

--- a/pkg/obsidian/vault_default_name.go
+++ b/pkg/obsidian/vault_default_name.go
@@ -3,12 +3,15 @@ package obsidian
 import (
 	"encoding/json"
 	"errors"
-	"github.com/Yakitrak/obsidian-cli/pkg/config"
 	"os"
+
+	"github.com/Yakitrak/obsidian-cli/pkg/config"
 )
 
-var CliConfigPath = config.CliPath
-var JsonMarshal = json.Marshal
+var (
+	CliConfigPath = config.CliPath
+	JsonMarshal   = json.Marshal
+)
 
 func (v *Vault) DefaultName() (string, error) {
 	if v.Name != "" {
@@ -30,7 +33,6 @@ func (v *Vault) DefaultName() (string, error) {
 	// unmarshal json
 	cliConfig := CliConfig{}
 	err = json.Unmarshal(content, &cliConfig)
-
 	if err != nil {
 		return "", errors.New(ObsidianCLIConfigParseError)
 	}
@@ -64,7 +66,7 @@ func (v *Vault) SetDefaultName(name string) error {
 	}
 
 	// create and write file
-	err = os.WriteFile(obsConfigFile, jsonContent, 0644)
+	err = os.WriteFile(obsConfigFile, jsonContent, 0o644)
 	if err != nil {
 		return errors.New(ObsidianCLIConfigWriteError)
 	}

--- a/pkg/obsidian/vault_default_name_test.go
+++ b/pkg/obsidian/vault_default_name_test.go
@@ -2,11 +2,12 @@ package obsidian_test
 
 import (
 	"errors"
+	"os"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestVaultDefaultName(t *testing.T) {
@@ -30,7 +31,7 @@ func TestVaultDefaultName(t *testing.T) {
 			obsidian.CliConfigPath = func() (string, string, error) {
 				return mockCliConfigDir, mockCliConfigFile, nil
 			}
-			err := os.WriteFile(mockCliConfigFile, []byte(`{"default_vault_name":"example-obsidian"}`), 0644)
+			err := os.WriteFile(mockCliConfigFile, []byte(`{"default_vault_name":"example-obsidian"}`), 0o644)
 			vault := obsidian.Vault{}
 			// Act
 			vaultName, err := vault.DefaultName()
@@ -41,7 +42,6 @@ func TestVaultDefaultName(t *testing.T) {
 	})
 
 	t.Run("Could not get vault name", func(t *testing.T) {
-
 		t.Run("Error in config.CliPath", func(t *testing.T) {
 			// Arrange
 			obsidian.CliConfigPath = func() (string, string, error) {
@@ -73,7 +73,7 @@ func TestVaultDefaultName(t *testing.T) {
 			obsidian.CliConfigPath = func() (string, string, error) {
 				return mockCliConfigDir, mockCliConfigFile, nil
 			}
-			err := os.WriteFile(mockCliConfigFile, []byte(`{"default_vault_name""example-obsidian`), 0644)
+			err := os.WriteFile(mockCliConfigFile, []byte(`{"default_vault_name""example-obsidian`), 0o644)
 			vault := obsidian.Vault{}
 			// Act
 			_, err = vault.DefaultName()
@@ -87,7 +87,7 @@ func TestVaultDefaultName(t *testing.T) {
 			obsidian.CliConfigPath = func() (string, string, error) {
 				return mockCliConfigDir, mockCliConfigFile, nil
 			}
-			err := os.WriteFile(mockCliConfigFile, []byte(`{"default_vault_name":""}`), 0644)
+			err := os.WriteFile(mockCliConfigFile, []byte(`{"default_vault_name":""}`), 0o644)
 			vault := obsidian.Vault{}
 			// Act
 			_, err = vault.DefaultName()
@@ -164,12 +164,11 @@ func TestVaultSetDefaultName(t *testing.T) {
 		obsidian.CliConfigPath = func() (string, string, error) {
 			return mockCliConfigDir + "/unwrittable", mockCliConfigDir + "unwrittable/preferences.json", nil
 		}
-		err := os.Mkdir(mockCliConfigDir+"/unwrittable", 0444)
+		err := os.Mkdir(mockCliConfigDir+"/unwrittable", 0o444)
 		vault := obsidian.Vault{}
 		// Act
 		err = vault.SetDefaultName("vault-name")
 		// Assert
 		assert.Equal(t, err.Error(), obsidian.ObsidianCLIConfigWriteError)
 	})
-
 }

--- a/pkg/obsidian/vault_path.go
+++ b/pkg/obsidian/vault_path.go
@@ -3,9 +3,10 @@ package obsidian
 import (
 	"encoding/json"
 	"errors"
-	"github.com/Yakitrak/obsidian-cli/pkg/config"
 	"os"
 	"strings"
+
+	"github.com/Yakitrak/obsidian-cli/pkg/config"
 )
 
 var ObsidianConfigFile = config.ObsidianFile
@@ -17,14 +18,12 @@ func (v *Vault) Path() (string, error) {
 	}
 
 	content, err := os.ReadFile(obsidianConfigFile)
-
 	if err != nil {
 		return "", errors.New(ObsidianConfigReadError)
 	}
 
 	vaultsContent := ObsidianVaultConfig{}
 	err = json.Unmarshal(content, &vaultsContent)
-
 	if err != nil {
 		return "", errors.New(ObsidianConfigParseError)
 	}

--- a/pkg/obsidian/vault_path_test.go
+++ b/pkg/obsidian/vault_path_test.go
@@ -1,11 +1,12 @@
 package obsidian_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/Yakitrak/obsidian-cli/mocks"
 	"github.com/Yakitrak/obsidian-cli/pkg/obsidian"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestVaultPath(t *testing.T) {
@@ -27,7 +28,7 @@ func TestVaultPath(t *testing.T) {
 	obsidian.ObsidianConfigFile = func() (string, error) {
 		return mockObsidianConfigFile, nil
 	}
-	err := os.WriteFile(mockObsidianConfigFile, []byte(obsidianConfig), 0644)
+	err := os.WriteFile(mockObsidianConfigFile, []byte(obsidianConfig), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create obsidian.json file: %v", err)
 	}
@@ -60,7 +61,7 @@ func TestVaultPath(t *testing.T) {
 		obsidian.ObsidianConfigFile = func() (string, error) {
 			return mockObsidianConfigFile, nil
 		}
-		err := os.WriteFile(mockObsidianConfigFile, []byte(``), 0000)
+		err := os.WriteFile(mockObsidianConfigFile, []byte(``), 0o000)
 		if err != nil {
 			t.Fatalf("Failed to create obsidian.json file: %v", err)
 		}
@@ -69,7 +70,6 @@ func TestVaultPath(t *testing.T) {
 		_, err = vault.Path()
 		// Assert
 		assert.Equal(t, err.Error(), obsidian.ObsidianConfigReadError)
-
 	})
 
 	t.Run("Error in unmarshalling obsidian config file", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestVaultPath(t *testing.T) {
 			return mockObsidianConfigFile, nil
 		}
 
-		err := os.WriteFile(mockObsidianConfigFile, []byte(`abc`), 0644)
+		err := os.WriteFile(mockObsidianConfigFile, []byte(`abc`), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to create obsidian.json file: %v", err)
 		}
@@ -87,7 +87,6 @@ func TestVaultPath(t *testing.T) {
 		_, err = vault.Path()
 		// Assert
 		assert.Equal(t, err.Error(), obsidian.ObsidianConfigParseError)
-
 	})
 
 	t.Run("No vault found with given name", func(t *testing.T) {
@@ -95,7 +94,7 @@ func TestVaultPath(t *testing.T) {
 		obsidian.ObsidianConfigFile = func() (string, error) {
 			return mockObsidianConfigFile, nil
 		}
-		err := os.WriteFile(mockObsidianConfigFile, []byte(`{"vaults":{}}`), 0644)
+		err := os.WriteFile(mockObsidianConfigFile, []byte(`{"vaults":{}}`), 0o644)
 		vault := obsidian.Vault{Name: "vault3"}
 		// Act
 		_, err = vault.Path()


### PR DESCRIPTION
# Pretty print go code

**Description**
`make fmt` runs docker with gofumpt to keep code formatted.

**Motivation and Context**
Eliminate noisy diffs by choosing a code pretty printer.

**Checklist:**
- [ ] I have written unit tests for my changes.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.