### PR TITLE
add section flag to open command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ obsidian-cli open "{note-name}"
 # Opens note in specified obsidian vault
 obsidian-cli open "{note-name}" --vault "{vault-name}"
 
+# Opens note at a specific heading (case-sensitive)
+obsidian-cli open "{note-name}" --section "{heading-text}"
+
+obsidian-cli open "{note-name}" --vault "{vault-name}" --section "{heading-text}"
 ```
 
 ### Daily Note

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -9,6 +9,7 @@ import (
 )
 
 var vaultName string
+var sectionName string
 var OpenVaultCmd = &cobra.Command{
 	Use:     "open",
 	Aliases: []string{"o"},
@@ -18,7 +19,7 @@ var OpenVaultCmd = &cobra.Command{
 		vault := obsidian.Vault{Name: vaultName}
 		uri := obsidian.Uri{}
 		noteName := args[0]
-		params := actions.OpenParams{NoteName: noteName}
+		params := actions.OpenParams{NoteName: noteName, Section: sectionName}
 		err := actions.OpenNote(&vault, &uri, params)
 		if err != nil {
 			log.Fatal(err)
@@ -28,5 +29,6 @@ var OpenVaultCmd = &cobra.Command{
 
 func init() {
 	OpenVaultCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name (not required if default is set)")
+	OpenVaultCmd.Flags().StringVarP(&sectionName, "section", "s", "", "heading text to open within the note (case-sensitive)")
 	rootCmd.AddCommand(OpenVaultCmd)
 }

--- a/mocks/uri.go
+++ b/mocks/uri.go
@@ -2,10 +2,14 @@ package mocks
 
 type MockUriManager struct {
 	ConstructedURI string
+	LastBase       string
+	LastParams     map[string]string
 	ExecuteErr     error
 }
 
 func (m *MockUriManager) Construct(base string, params map[string]string) string {
+	m.LastBase = base
+	m.LastParams = params
 	return m.ConstructedURI
 }
 

--- a/pkg/actions/open.go
+++ b/pkg/actions/open.go
@@ -6,6 +6,7 @@ import (
 
 type OpenParams struct {
 	NoteName string
+	Section  string
 }
 
 func OpenNote(vault obsidian.VaultManager, uri obsidian.UriManager, params OpenParams) error {
@@ -14,9 +15,14 @@ func OpenNote(vault obsidian.VaultManager, uri obsidian.UriManager, params OpenP
 		return err
 	}
 
+	fileParam := params.NoteName
+	if params.Section != "" {
+		fileParam = params.NoteName + "#" + params.Section
+	}
+
 	obsidianUri := uri.Construct(ObsOpenUrl, map[string]string{
 		"vault": vaultName,
-		"file":  params.NoteName,
+		"file":  fileParam,
 	})
 
 	err = uri.Execute(obsidianUri)

--- a/pkg/actions/open_test.go
+++ b/pkg/actions/open_test.go
@@ -20,6 +20,8 @@ func TestOpenNote(t *testing.T) {
 		})
 		// Assert
 		assert.Equal(t, err, nil)
+		assert.Equal(t, "myVault", uri.LastParams["vault"])
+		assert.Equal(t, "note.md", uri.LastParams["file"])
 	})
 
 	t.Run("vault.DefaultName returns an error", func(t *testing.T) {
@@ -44,8 +46,23 @@ func TestOpenNote(t *testing.T) {
 		// Act
 		err := actions.OpenNote(&mocks.MockVaultOperator{}, &uri, actions.OpenParams{
 			NoteName: "note1.md",
+			Section:  "Heading One",
 		})
 		// Assert
 		assert.Equal(t, err, uri.ExecuteErr)
+		assert.Equal(t, "note1.md#Heading One", uri.LastParams["file"])
+	})
+
+	t.Run("Opens note with section", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+
+		err := actions.OpenNote(&vault, &uri, actions.OpenParams{
+			NoteName: "note.md",
+			Section:  "Section Name",
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "note.md#Section Name", uri.LastParams["file"])
 	})
 }


### PR DESCRIPTION
Add `open --section` heading navigation

**Description**
- Introduced `--section` flag to open notes at a specific heading.
- Updated `OpenParams` to include `Section`.
- Modified `OpenNote` to append `#<heading>` to the file parameter.
- Enhanced tests to cover section behavior.
- Updated README with new `open --section` usage.

**Motivation and Context**
Issue #71 requests direct section navigation when opening long notes. This change allows users to jump to an exact heading using Obsidian’s URI behavior, while keeping default `open` behavior unchanged.

**Checklist:**
- [x] I have written unit tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.