### PR TITLE
document how to install from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ brew tap yakitrak/yakitrak
 brew install yakitrak/yakitrak/notesmd-cli
 ```
 
+### Arch Linux (AUR)
+
+Install with your preferred AUR helper:
+
+```bash
+paru -S notesmd-cli-bin
+```
+
+```bash
+yay -S notesmd-cli-bin
+```
+
+### Build from Source
+
+Requires [Go](https://go.dev/dl/) 1.19 or later.
+
+```bash
+git clone https://github.com/yakitrak/notesmd-cli.git
+cd notesmd-cli
+go build -o notesmd-cli .
+sudo install -m 755 notesmd-cli /usr/local/bin/
+```
+
+---
+
 ## Migrating from Obsidian CLI
 
 **Upgrading from `obsidian-cli` v0.2.3 or earlier?** See the detailed [Migration Guide](MIGRATION.md) for step-by-step instructions on uninstalling the old version, installing Vault CLI, and migrating your configuration.


### PR DESCRIPTION
# document how to install from AUR

**Description**
document how to install from AUR - with `yay` and `paru`

**Motivation and Context**
I wanted to publish it on AUR to help people avoid installing `brew` on their linux machines. But since `.goreleaser.yml` already does it I just documented it.

**Checklist:**
- [-] I have written unit tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.