### PR TITLE
fix: address review feedback on PR #89

### DIFF
--- a/cmd/set_default.go
+++ b/cmd/set_default.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/Yakitrak/notesmd-cli/pkg/obsidian"
 	"github.com/spf13/cobra"
@@ -29,12 +30,15 @@ var setDefaultCmd = &cobra.Command{
 			if err := v.SetDefaultName(name); err != nil {
 				log.Fatal(err)
 			}
+			fmt.Println("Default vault set to:", name)
 			path, err := v.Path()
 			if err != nil {
-				log.Fatal(err)
+				// Path resolution is best-effort: the name is saved; Obsidian's
+				// config file may not be present or may not contain this vault yet.
+				fmt.Fprintln(os.Stderr, "Note: could not resolve vault path:", err)
+			} else {
+				fmt.Println("Default vault path set to:", path)
 			}
-			fmt.Println("Default vault set to:", name)
-			fmt.Println("Default vault path set to:", path)
 		}
 
 		if openType != "" {

--- a/pkg/obsidian/vault_path.go
+++ b/pkg/obsidian/vault_path.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/Yakitrak/notesmd-cli/pkg/config"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -12,6 +13,12 @@ var ObsidianConfigFile = config.ObsidianFile
 var RunningInWSL = config.RunningInWSL
 
 func (v *Vault) Path() (string, error) {
+	// If the stored name is already an absolute path, return it directly
+	// without requiring Obsidian's config file to be present.
+	if filepath.IsAbs(v.Name) {
+		return v.Name, nil
+	}
+
 	obsidianConfigFile, err := ObsidianConfigFile()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Closes #89

Addresses the review comments from #89:

- **`vault_path.go`**: return absolute path names directly without reading `obsidian.json`, handling the common case of storing full paths as the default vault
- **`set_default.go`**: path resolution after setting the vault name is best-effort; use `fmt.Fprintln(os.Stderr, ...)` instead of `log.Printf` for consistency with surrounding `fmt.Println` calls
- **`vault_path_test.go`**: use `t.Cleanup` for mock restore so it runs even if `t.Fatal` fires inside the mock; fix WSL C: drive test to use `"Obsidian Vault"` as the vault name matching the path suffix

**Checklist:**
- [x] I have written unit tests for my changes.
- [x] All new and existing tests passed.