### PR TITLE
feat(search-content): add non-interactive output modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ clean-all:
 test:
 	go test ./...
 
+test-search-content:
+	go test ./pkg/actions -run TestSearchNotesContent -v
+
 test-coverage:
 	go test ./... -coverprofile=coverage.out
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ notesmd-cli search --editor
 
 ### Search Note Content
 
-Searches for notes containing search term in the content of notes. It will display a list of matching notes with the line number and a snippet of the matching line. You can hit enter on a note to open that in Obsidian.
+Searches for notes containing a term in note content. By default, it opens an interactive picker and lets you open the selected note in Obsidian (or your editor). For automation and scripting, use `--no-interactive` or `--format json` to print results to stdout.
 
 ```bash
 # Searches for content in default obsidian vault
@@ -239,6 +239,12 @@ notesmd-cli search-content "search term" --vault "{vault-name}"
 
 # Searches and opens selected note in your default editor
 notesmd-cli search-content "search term" --editor
+
+# Prints grep-style results to stdout (non-interactive)
+notesmd-cli search-content "search term" --no-interactive
+
+# Prints JSON for scripts (implies non-interactive mode)
+notesmd-cli search-content "search term" --format json
 
 ```
 

--- a/cmd/search_content.go
+++ b/cmd/search_content.go
@@ -2,16 +2,17 @@ package cmd
 
 import (
 	"log"
+	"os"
 
 	"github.com/Yakitrak/notesmd-cli/pkg/actions"
 	"github.com/Yakitrak/notesmd-cli/pkg/obsidian"
-
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var searchContentCmd = &cobra.Command{
 	Use:     "search-content [search term]",
-	Short:   "Search node content for search term",
+	Short:   "Search note content for search term",
 	Args:    cobra.ExactArgs(1),
 	Aliases: []string{"sc"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -21,15 +22,49 @@ var searchContentCmd = &cobra.Command{
 		fuzzyFinder := obsidian.FuzzyFinder{}
 
 		searchTerm := args[0]
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, searchTerm, resolveUseEditor(cmd, &vault))
+		options, err := buildSearchContentOptions(cmd, &vault, isInteractiveTerminal())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, searchTerm, options)
 		if err != nil {
 			log.Fatal(err)
 		}
 	},
 }
 
+func buildSearchContentOptions(cmd *cobra.Command, vault obsidian.VaultManager, interactiveTerminal bool) (actions.SearchContentOptions, error) {
+	noInteractive, err := cmd.Flags().GetBool("no-interactive")
+	if err != nil {
+		return actions.SearchContentOptions{}, err
+	}
+
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return actions.SearchContentOptions{}, err
+	}
+
+	useEditor := resolveUseEditor(cmd, vault)
+
+	return actions.SearchContentOptions{
+		UseEditor:           useEditor,
+		EditorFlagExplicit:  cmd.Flags().Changed("editor"),
+		NoInteractive:       noInteractive,
+		Format:              format,
+		InteractiveTerminal: interactiveTerminal,
+		Output:              os.Stdout,
+	}, nil
+}
+
+func isInteractiveTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
 func init() {
 	searchContentCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name")
 	searchContentCmd.Flags().BoolP("editor", "e", false, "open in editor instead of Obsidian")
+	searchContentCmd.Flags().Bool("no-interactive", false, "disable interactive selection and print results to stdout")
+	searchContentCmd.Flags().String("format", "text", "output format for non-interactive mode: text|json")
 	rootCmd.AddCommand(searchContentCmd)
 }

--- a/cmd/search_content_test.go
+++ b/cmd/search_content_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubVaultManager struct {
+	defaultName    string
+	defaultNameErr error
+	path           string
+	pathErr        error
+	openType       string
+	openTypeErr    error
+}
+
+func (s *stubVaultManager) DefaultName() (string, error) {
+	if s.defaultNameErr != nil {
+		return "", s.defaultNameErr
+	}
+	if s.defaultName == "" {
+		return "vault", nil
+	}
+	return s.defaultName, nil
+}
+
+func (s *stubVaultManager) SetDefaultName(name string) error {
+	s.defaultName = name
+	return nil
+}
+
+func (s *stubVaultManager) Path() (string, error) {
+	if s.pathErr != nil {
+		return "", s.pathErr
+	}
+	if s.path == "" {
+		return "path", nil
+	}
+	return s.path, nil
+}
+
+func (s *stubVaultManager) DefaultOpenType() (string, error) {
+	if s.openTypeErr != nil {
+		return "", s.openTypeErr
+	}
+	if s.openType == "" {
+		return "obsidian", nil
+	}
+	return s.openType, nil
+}
+
+func newSearchContentOptionsTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "test"}
+	c.Flags().BoolP("editor", "e", false, "")
+	c.Flags().Bool("no-interactive", false, "")
+	c.Flags().String("format", "text", "")
+	return c
+}
+
+func TestSearchContentCommandFlagsWired(t *testing.T) {
+	assert.NotNil(t, searchContentCmd.Flags().Lookup("no-interactive"))
+	assert.NotNil(t, searchContentCmd.Flags().Lookup("format"))
+	assert.NotNil(t, searchContentCmd.Flags().Lookup("editor"))
+	assert.NotNil(t, searchContentCmd.Flags().Lookup("vault"))
+
+	assert.Equal(t, "text", searchContentCmd.Flags().Lookup("format").DefValue)
+	assert.Contains(t, searchContentCmd.Aliases, "sc")
+}
+
+func TestBuildSearchContentOptionsParsesExplicitFlags(t *testing.T) {
+	c := newSearchContentOptionsTestCmd()
+	err := c.ParseFlags([]string{"--editor", "--no-interactive", "--format", "json"})
+	assert.NoError(t, err)
+
+	vault := &stubVaultManager{openType: "obsidian"}
+	options, err := buildSearchContentOptions(c, vault, false)
+	assert.NoError(t, err)
+	assert.True(t, options.UseEditor)
+	assert.True(t, options.EditorFlagExplicit)
+	assert.True(t, options.NoInteractive)
+	assert.Equal(t, "json", options.Format)
+	assert.False(t, options.InteractiveTerminal)
+	assert.NotNil(t, options.Output)
+}
+
+func TestBuildSearchContentOptionsRespectsDefaultOpenType(t *testing.T) {
+	c := newSearchContentOptionsTestCmd()
+	err := c.ParseFlags([]string{})
+	assert.NoError(t, err)
+
+	vault := &stubVaultManager{openType: "editor"}
+	options, err := buildSearchContentOptions(c, vault, true)
+	assert.NoError(t, err)
+	assert.True(t, options.UseEditor)
+	assert.False(t, options.EditorFlagExplicit)
+	assert.False(t, options.NoInteractive)
+	assert.Equal(t, "text", options.Format)
+	assert.True(t, options.InteractiveTerminal)
+}
+
+func TestBuildSearchContentOptionsDefaultOpenTypeErrorFallsBack(t *testing.T) {
+	c := newSearchContentOptionsTestCmd()
+	err := c.ParseFlags([]string{})
+	assert.NoError(t, err)
+
+	vault := &stubVaultManager{openTypeErr: errors.New("config error")}
+	options, err := buildSearchContentOptions(c, vault, true)
+	assert.NoError(t, err)
+	assert.False(t, options.UseEditor)
+	assert.False(t, options.EditorFlagExplicit)
+}

--- a/mocks/uri.go
+++ b/mocks/uri.go
@@ -5,6 +5,7 @@ type MockUriManager struct {
 	LastBase       string
 	LastParams     map[string]string
 	ExecuteErr     error
+	ExecuteCalls   int
 }
 
 func (m *MockUriManager) Construct(base string, params map[string]string) string {
@@ -14,5 +15,6 @@ func (m *MockUriManager) Construct(base string, params map[string]string) string
 }
 
 func (m *MockUriManager) Execute(uri string) error {
+	m.ExecuteCalls++
 	return m.ExecuteErr
 }

--- a/pkg/actions/search_content.go
+++ b/pkg/actions/search_content.go
@@ -1,13 +1,73 @@
 package actions
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Yakitrak/notesmd-cli/pkg/obsidian"
 )
 
+const (
+	searchContentFormatText = "text"
+	searchContentFormatJSON = "json"
+)
+
+type SearchContentOptions struct {
+	UseEditor           bool
+	EditorFlagExplicit  bool
+	NoInteractive       bool
+	Format              string
+	InteractiveTerminal bool
+	Output              io.Writer
+}
+
+type searchContentJSONMatch struct {
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	Content   string `json:"content"`
+	MatchType string `json:"match_type"`
+}
+
+// SearchNotesContent preserves backward-compatible interactive behavior.
 func SearchNotesContent(vault obsidian.VaultManager, note obsidian.NoteManager, uri obsidian.UriManager, fuzzyFinder obsidian.FuzzyFinderManager, searchTerm string, useEditor bool) error {
+	return SearchNotesContentWithOptions(vault, note, uri, fuzzyFinder, searchTerm, SearchContentOptions{
+		UseEditor:           useEditor,
+		EditorFlagExplicit:  useEditor,
+		Format:              searchContentFormatText,
+		InteractiveTerminal: true,
+		Output:              os.Stdout,
+	})
+}
+
+func SearchNotesContentWithOptions(vault obsidian.VaultManager, note obsidian.NoteManager, uri obsidian.UriManager, fuzzyFinder obsidian.FuzzyFinderManager, searchTerm string, options SearchContentOptions) error {
+	format, err := normalizeSearchContentFormat(options.Format)
+	if err != nil {
+		return err
+	}
+
+	nonInteractiveMode := shouldUseNonInteractiveMode(options, format)
+	useEditor := options.UseEditor
+
+	if nonInteractiveMode && options.EditorFlagExplicit && options.UseEditor {
+		return errors.New("--editor cannot be used with non-interactive search-content output")
+	}
+
+	if nonInteractiveMode {
+		// If editor mode came from config default rather than explicit flag,
+		// prefer non-interactive output for script-friendly behavior.
+		useEditor = false
+	}
+
+	output := options.Output
+	if output == nil {
+		output = os.Stdout
+	}
+
 	vaultName, err := vault.DefaultName()
 	if err != nil {
 		return err
@@ -23,13 +83,17 @@ func SearchNotesContent(vault obsidian.VaultManager, note obsidian.NoteManager, 
 		return err
 	}
 
+	if nonInteractiveMode {
+		return printMatches(matches, searchTerm, format, output)
+	}
+
 	if len(matches) == 0 {
-		fmt.Printf("No notes found containing '%s'\n", searchTerm)
+		fmt.Fprintf(output, "No notes found containing '%s'\n", searchTerm)
 		return nil
 	}
 
 	if len(matches) == 1 {
-		fmt.Printf("Opening note: %s\n", matches[0].FilePath)
+		fmt.Fprintf(output, "Opening note: %s\n", matches[0].FilePath)
 		if useEditor {
 			filePath := filepath.Join(vaultPath, matches[0].FilePath)
 			return obsidian.OpenInEditor(filePath)
@@ -53,7 +117,7 @@ func SearchNotesContent(vault obsidian.VaultManager, note obsidian.NoteManager, 
 	selectedMatch := matches[index]
 	if useEditor {
 		filePath := filepath.Join(vaultPath, selectedMatch.FilePath)
-		fmt.Printf("Opening note: %s\n", selectedMatch.FilePath)
+		fmt.Fprintf(output, "Opening note: %s\n", selectedMatch.FilePath)
 		return obsidian.OpenInEditor(filePath)
 	}
 	obsidianUri := uri.Construct(ObsOpenUrl, map[string]string{
@@ -61,6 +125,74 @@ func SearchNotesContent(vault obsidian.VaultManager, note obsidian.NoteManager, 
 		"vault": vaultName,
 	})
 	return uri.Execute(obsidianUri)
+}
+
+func shouldUseNonInteractiveMode(options SearchContentOptions, format string) bool {
+	if options.NoInteractive {
+		return true
+	}
+	if format == searchContentFormatJSON {
+		return true
+	}
+	return !options.InteractiveTerminal
+}
+
+func normalizeSearchContentFormat(format string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(format))
+	if trimmed == "" {
+		return searchContentFormatText, nil
+	}
+
+	switch trimmed {
+	case searchContentFormatText, searchContentFormatJSON:
+		return trimmed, nil
+	default:
+		return "", fmt.Errorf("invalid format '%s': expected one of text, json", format)
+	}
+}
+
+func printMatches(matches []obsidian.NoteMatch, searchTerm string, format string, output io.Writer) error {
+	switch format {
+	case searchContentFormatText:
+		if len(matches) == 0 {
+			fmt.Fprintf(os.Stderr, "No notes found containing '%s'\n", searchTerm)
+			return nil
+		}
+		for _, match := range matches {
+			fmt.Fprintln(output, formatMatchForList(match))
+		}
+		return nil
+	case searchContentFormatJSON:
+		result := make([]searchContentJSONMatch, 0, len(matches))
+		for _, match := range matches {
+			result = append(result, searchContentJSONMatch{
+				File:      match.FilePath,
+				Line:      match.LineNumber,
+				Content:   match.MatchLine,
+				MatchType: getMatchType(match),
+			})
+		}
+
+		encoder := json.NewEncoder(output)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(result)
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+func formatMatchForList(match obsidian.NoteMatch) string {
+	if match.LineNumber > 0 {
+		return fmt.Sprintf("%s:%d: %s", match.FilePath, match.LineNumber, match.MatchLine)
+	}
+	return fmt.Sprintf("%s: %s", match.FilePath, match.MatchLine)
+}
+
+func getMatchType(match obsidian.NoteMatch) string {
+	if match.LineNumber == 0 {
+		return "filename"
+	}
+	return "content"
 }
 
 func formatMatchesForDisplay(matches []obsidian.NoteMatch) []string {

--- a/pkg/actions/search_content_test.go
+++ b/pkg/actions/search_content_test.go
@@ -1,7 +1,10 @@
 package actions_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"testing"
 
@@ -12,6 +15,7 @@ import (
 )
 
 // CustomMockNoteForSingleMatch returns exactly one match for editor testing
+// and for checking single-result interactive behavior.
 type CustomMockNoteForSingleMatch struct{}
 
 func (m *CustomMockNoteForSingleMatch) Delete(string) error                        { return nil }
@@ -29,60 +33,123 @@ func (m *CustomMockNoteForSingleMatch) FindBacklinks(string, string) ([]obsidian
 	return nil, nil
 }
 
+type searchContentJSONMatch struct {
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	Content   string `json:"content"`
+	MatchType string `json:"match_type"`
+}
+
+func defaultOptions(output *bytes.Buffer) actions.SearchContentOptions {
+	return actions.SearchContentOptions{
+		Format:              "text",
+		InteractiveTerminal: true,
+		Output:              output,
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stderr = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	stderrBytes, readErr := io.ReadAll(r)
+	assert.NoError(t, readErr)
+	_ = r.Close()
+	return string(stderrBytes)
+}
+
 func TestSearchNotesContent(t *testing.T) {
-	t.Run("Successful content search with single match", func(t *testing.T) {
+	t.Run("Backward compatible SearchNotesContent API still works", func(t *testing.T) {
 		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
 		note := mocks.MockNoteManager{}
-		fuzzyFinder := mocks.MockFuzzyFinder{}
+		fuzzyFinder := mocks.MockFuzzyFinder{SelectedIndex: 0}
 
 		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", false)
 		assert.NoError(t, err)
+		assert.Equal(t, 1, uri.ExecuteCalls)
 	})
 
-	t.Run("No matches found", func(t *testing.T) {
+	t.Run("Successful interactive content search with multiple matches", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{SelectedIndex: 0}
+		output := &bytes.Buffer{}
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", defaultOptions(output))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, uri.ExecuteCalls)
+	})
+
+	t.Run("No matches found in interactive mode", func(t *testing.T) {
 		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
 		note := mocks.MockNoteManager{NoMatches: true}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "nonexistent", false)
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "nonexistent", defaultOptions(output))
 		assert.NoError(t, err)
+		assert.Contains(t, output.String(), "No notes found containing 'nonexistent'")
+	})
+
+	t.Run("No matches found in non-interactive text mode prints message to stderr", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{NoMatches: true}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.NoInteractive = true
+
+		stderr := captureStderr(t, func() {
+			err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "nonexistent", options)
+			assert.NoError(t, err)
+		})
+
+		assert.Equal(t, "", output.String())
+		assert.Contains(t, stderr, "No notes found containing 'nonexistent'")
 	})
 
 	t.Run("SearchNotesWithSnippets returns error", func(t *testing.T) {
 		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
-		note := mocks.MockNoteManager{
-			GetContentsError: errors.New("search failed"),
-		}
+		note := mocks.MockNoteManager{GetContentsError: errors.New("search failed")}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", false)
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", defaultOptions(output))
 		assert.Error(t, err)
 	})
 
 	t.Run("vault.DefaultName returns error", func(t *testing.T) {
-		vault := mocks.MockVaultOperator{
-			DefaultNameErr: errors.New("vault name error"),
-		}
+		vault := mocks.MockVaultOperator{DefaultNameErr: errors.New("vault name error")}
 		uri := mocks.MockUriManager{}
 		note := mocks.MockNoteManager{}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", false)
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", defaultOptions(output))
 		assert.Error(t, err)
 	})
 
 	t.Run("vault.Path returns error", func(t *testing.T) {
-		vault := mocks.MockVaultOperator{
-			PathError: errors.New("vault path error"),
-		}
+		vault := mocks.MockVaultOperator{PathError: errors.New("vault path error")}
 		uri := mocks.MockUriManager{}
 		note := mocks.MockNoteManager{}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", false)
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", defaultOptions(output))
 		assert.Error(t, err)
 	})
 
@@ -90,89 +157,201 @@ func TestSearchNotesContent(t *testing.T) {
 		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
 		note := mocks.MockNoteManager{}
-		fuzzyFinder := mocks.MockFuzzyFinder{
-			FindErr: errors.New("fuzzy finder error"),
-		}
+		fuzzyFinder := mocks.MockFuzzyFinder{FindErr: errors.New("fuzzy finder error")}
+		output := &bytes.Buffer{}
 
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", false)
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", defaultOptions(output))
 		assert.Error(t, err)
 	})
 
 	t.Run("uri execution returns error", func(t *testing.T) {
 		vault := mocks.MockVaultOperator{Name: "myVault"}
-		uri := mocks.MockUriManager{
-			ExecuteErr: errors.New("uri execution error"),
-		}
+		uri := mocks.MockUriManager{ExecuteErr: errors.New("uri execution error")}
 		note := mocks.MockNoteManager{}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", false)
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", defaultOptions(output))
 		assert.Error(t, err)
 	})
 
 	t.Run("Successful content search with editor flag - single match", func(t *testing.T) {
-		// Set up mocks for single match scenario
-		vault := mocks.MockVaultOperator{
-			Name: "myVault",
-		}
+		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
-		// Create a custom mock that returns exactly one match
 		note := &CustomMockNoteForSingleMatch{}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		// Set EDITOR to a command that will succeed
 		originalEditor := os.Getenv("EDITOR")
 		defer os.Setenv("EDITOR", originalEditor)
 		os.Setenv("EDITOR", "true")
 
-		// Act - test with editor flag enabled
-		err := actions.SearchNotesContent(&vault, note, &uri, &fuzzyFinder, "test", true)
+		options := defaultOptions(output)
+		options.UseEditor = true
+		options.EditorFlagExplicit = true
 
-		// Assert - should succeed without calling URI execute
+		err := actions.SearchNotesContentWithOptions(&vault, note, &uri, &fuzzyFinder, "test", options)
 		assert.NoError(t, err)
+		assert.Equal(t, 0, uri.ExecuteCalls)
 	})
 
 	t.Run("Successful content search with editor flag - multiple matches", func(t *testing.T) {
-		// Set up mocks for multiple match scenario
-		vault := mocks.MockVaultOperator{
-			Name: "myVault",
-		}
+		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
-		note := mocks.MockNoteManager{} // This returns 2 matches by default
-		fuzzyFinder := mocks.MockFuzzyFinder{
-			SelectedIndex: 0,
-		}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{SelectedIndex: 0}
+		output := &bytes.Buffer{}
 
-		// Set EDITOR to a command that will succeed
 		originalEditor := os.Getenv("EDITOR")
 		defer os.Setenv("EDITOR", originalEditor)
 		os.Setenv("EDITOR", "true")
 
-		// Act - test with editor flag enabled
-		err := actions.SearchNotesContent(&vault, &note, &uri, &fuzzyFinder, "test", true)
+		options := defaultOptions(output)
+		options.UseEditor = true
+		options.EditorFlagExplicit = true
 
-		// Assert - should succeed without calling URI execute
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
 		assert.NoError(t, err)
+		assert.Equal(t, 0, uri.ExecuteCalls)
 	})
 
 	t.Run("Content search with editor flag fails when editor fails", func(t *testing.T) {
-		// Set up mocks for single match scenario
-		vault := mocks.MockVaultOperator{
-			Name: "myVault",
-		}
+		vault := mocks.MockVaultOperator{Name: "myVault"}
 		uri := mocks.MockUriManager{}
 		note := &CustomMockNoteForSingleMatch{}
 		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
 
-		// Set EDITOR to a command that will fail
 		originalEditor := os.Getenv("EDITOR")
 		defer os.Setenv("EDITOR", originalEditor)
-		os.Setenv("EDITOR", "false") // 'false' command always fails
+		os.Setenv("EDITOR", "false")
 
-		// Act - test with editor flag enabled
-		err := actions.SearchNotesContent(&vault, note, &uri, &fuzzyFinder, "test", true)
+		options := defaultOptions(output)
+		options.UseEditor = true
+		options.EditorFlagExplicit = true
 
-		// Assert - should fail due to editor failure
+		err := actions.SearchNotesContentWithOptions(&vault, note, &uri, &fuzzyFinder, "test", options)
 		assert.Error(t, err)
+	})
+
+	t.Run("No-interactive flag forces text output", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.NoInteractive = true
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.NoError(t, err)
+		assert.Equal(t, "note1.md:5: example match line\nnote2.md:10: another match\n", output.String())
+		assert.Equal(t, 0, uri.ExecuteCalls)
+	})
+
+	t.Run("JSON format outputs structured data", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.Format = "json"
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, uri.ExecuteCalls)
+
+		var result []searchContentJSONMatch
+		decodeErr := json.Unmarshal(output.Bytes(), &result)
+		assert.NoError(t, decodeErr)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "note1.md", result[0].File)
+		assert.Equal(t, 5, result[0].Line)
+		assert.Equal(t, "example match line", result[0].Content)
+		assert.Equal(t, "content", result[0].MatchType)
+	})
+
+	t.Run("JSON format with no matches prints empty array", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{NoMatches: true}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.Format = "json"
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.NoError(t, err)
+		assert.Equal(t, "[]\n", output.String())
+	})
+
+	t.Run("Non-interactive terminals auto-fallback to text output", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.InteractiveTerminal = false
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, uri.ExecuteCalls)
+		assert.Equal(t, "note1.md:5: example match line\nnote2.md:10: another match\n", output.String())
+	})
+
+	t.Run("Explicit editor flag returns error in non-interactive output mode", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.NoInteractive = true
+		options.UseEditor = true
+		options.EditorFlagExplicit = true
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "--editor cannot be used")
+	})
+
+	t.Run("Configured editor default is ignored in non-interactive terminals", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.InteractiveTerminal = false
+		options.UseEditor = true
+		options.EditorFlagExplicit = false
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, uri.ExecuteCalls)
+		assert.Equal(t, "note1.md:5: example match line\nnote2.md:10: another match\n", output.String())
+	})
+
+	t.Run("Invalid format returns error", func(t *testing.T) {
+		vault := mocks.MockVaultOperator{Name: "myVault"}
+		uri := mocks.MockUriManager{}
+		note := mocks.MockNoteManager{}
+		fuzzyFinder := mocks.MockFuzzyFinder{}
+		output := &bytes.Buffer{}
+
+		options := defaultOptions(output)
+		options.Format = "yaml"
+
+		err := actions.SearchNotesContentWithOptions(&vault, &note, &uri, &fuzzyFinder, "test", options)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid format")
 	})
 }


### PR DESCRIPTION
## Summary
- add non-interactive output support for `search-content` via `--list` and `--no-interactive`
- add `--format` with `text|json` (`json` implies non-interactive)
- auto-fallback to non-interactive text output when not running in a TTY
- reject explicit `--editor` in non-interactive mode and preserve configured editor fallback behavior safely
- preserve backward compatibility by keeping `SearchNotesContent(..., useEditor bool)` and introducing `SearchNotesContentWithOptions(...)`
- add command-level tests for flag wiring and option parsing
- add focused validation target `make test-search-content`
- update README usage examples for scripting/automation

## Validation
- `go test ./...`
- `make test-search-content`

Closes #75