### PR TITLE
docs: support headless setup without Obsidian installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ go build -o notesmd-cli .
 sudo install -m 755 notesmd-cli /usr/local/bin/
 ```
 
+### Headless / No Obsidian Installed 
+
+If you're running on a headless server or don't have Obsidian installed (e.g., server environments, containers, or systems without a GUI), you can still use this CLI. Obsidian requires a GUI, so this section explains how to set up the required configuration manually.
+
+**Setup Instructions:**
+
+1. Create the Obsidian config directory:
+   ```bash
+   mkdir -p ~/.config/obsidian
+   ```
+
+2. Create `obsidian.json` with your vault configuration:
+   ```json
+   {
+     "vaults": {
+       "your-vault-name": {
+         "path": "/path/to/your/vault"
+       }
+     }
+   }
+   ```
+   Replace `your-vault-name` with whatever name you want to use. For the path, use the **absolute path** — do not use `~` as the CLI does not expand it to your home directory.
+
 ---
 
 ## Migrating from Obsidian CLI


### PR DESCRIPTION
I run OpenClaw (a personal AI assistant) on a headless Raspberry Pi. I wanted to use `notesmd-cli` to manage my Obsidian vault, but couldn't install Obsidian since the official installer requires a GUI.

The CLI kept throwing errors even though the documentation says it doesn't require Obsidian to be running. After some debugging, I realized it still needs Obsidian's config file to exist.

I had to explore the source code to understand what configuration it expects, where it looks for it, and what format it needs to be in. Turns out, the CLI just needs the vault configuration in `~/.config/obsidian/obsidian.json` which gets created when you first run the Obsidian app.

This PR adds documentation for users in headless environments to manually create the required config and use the CLI without Obsidian installed.