### PR TITLE
docs: update AUR install instructions to include non-binary pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ brew install yakitrak/yakitrak/notesmd-cli
 
 ### Arch Linux (AUR)
 
-Install with your preferred AUR helper:
-
-```bash
-paru -S notesmd-cli-bin
+Install the offical binary with your preferred AUR helper:
+```sh
+yay -S notesmd-cli-bin
 ```
 
-```bash
-yay -S notesmd-cli-bin
+Or build from source:
+```sh
+yay -S notesmd-cli
 ```
 
 ### Build from Source


### PR DESCRIPTION
**Description**
Adds a reference to https://aur.archlinux.org/packages/notesmd-cli
(note: I am not the maintainer of that package :slightly_smiling_face: -> fyi @lmartinez-mirror )

**Motivation and Context**
Easier for users to have both options listed