### PR TITLE
feat: add validate command for note quality checking

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Yakitrak/notesmd-cli/pkg/obsidian"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate/rules"
+	"github.com/spf13/cobra"
+)
+
+var outputFormat string
+var minSeverity string
+
+var validateCmd = &cobra.Command{
+	Use:     "validate [path]",
+	Aliases: []string{"val"},
+	Short:   "Validate notes in a vault",
+	Long: `Validate notes in an Obsidian vault for common issues.
+
+Checks frontmatter syntax, deprecated properties, tag formatting,
+empty notes, and heading hierarchy.
+
+If a path is provided, only that note is validated.
+Otherwise, all notes in the vault are validated.`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		vault := obsidian.Vault{Name: vaultName}
+
+		config := validate.DefaultConfig()
+
+		// Parse severity flag
+		switch strings.ToLower(minSeverity) {
+		case "error":
+			config.MinSeverity = validate.SeverityError
+		case "warning":
+			config.MinSeverity = validate.SeverityWarning
+		case "info":
+			config.MinSeverity = validate.SeverityInfo
+		default:
+			log.Fatalf("Invalid severity: %s (use error, warning, or info)", minSeverity)
+		}
+
+		// Build the list of rules
+		allRules := []validate.RuleFunc{
+			rules.CheckFrontmatter,
+			rules.CheckStructure,
+		}
+
+		var summary *validate.ValidationSummary
+		var err error
+
+		if len(args) == 1 {
+			summary, err = validate.ValidatePath(&vault, args[0], config, allRules)
+		} else {
+			summary, err = validate.ValidateVault(&vault, config, allRules)
+		}
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Output results
+		switch strings.ToLower(outputFormat) {
+		case "json":
+			out, jsonErr := summary.ToJSON()
+			if jsonErr != nil {
+				log.Fatal(jsonErr)
+			}
+			fmt.Println(out)
+		case "summary":
+			printSummaryOnly(summary)
+		default:
+			printTextOutput(summary)
+		}
+
+		// Exit code 1 if errors found
+		if summary.HasErrors() {
+			os.Exit(1)
+		}
+	},
+}
+
+func printTextOutput(s *validate.ValidationSummary) {
+	fmt.Printf("Validating vault: %s (%d notes)\n\n", s.Vault, s.TotalNotes)
+
+	// Group results by file
+	grouped := make(map[string][]validate.ValidationResult)
+	var fileOrder []string
+	for _, r := range s.Results {
+		if _, seen := grouped[r.File]; !seen {
+			fileOrder = append(fileOrder, r.File)
+		}
+		grouped[r.File] = append(grouped[r.File], r)
+	}
+
+	for _, file := range fileOrder {
+		for _, r := range grouped[file] {
+			label := severityLabel(r.Severity)
+			fmt.Printf("%-5s %s\n", label, r.File)
+			msg := r.Message
+			if r.Line > 0 {
+				msg = fmt.Sprintf("%s (line %d)", msg, r.Line)
+			}
+			fmt.Printf("      %s\n", msg)
+			if r.Suggestion != "" {
+				fmt.Printf("      -> %s\n", r.Suggestion)
+			}
+			fmt.Println()
+		}
+	}
+
+	printSummaryLine(s)
+}
+
+func printSummaryOnly(s *validate.ValidationSummary) {
+	fmt.Printf("Vault: %s\n", s.Vault)
+	printSummaryLine(s)
+}
+
+func printSummaryLine(s *validate.ValidationSummary) {
+	fmt.Printf("Summary: %d notes, %d errors, %d warnings\n",
+		s.TotalNotes, s.Summary.Errors, s.Summary.Warnings)
+}
+
+func severityLabel(s validate.Severity) string {
+	switch s {
+	case validate.SeverityError:
+		return "ERR"
+	case validate.SeverityWarning:
+		return "WARN"
+	case validate.SeverityInfo:
+		return "INFO"
+	default:
+		return "???"
+	}
+}
+
+func init() {
+	validateCmd.Flags().StringVarP(&vaultName, "vault", "v", "", "vault name")
+	validateCmd.Flags().StringVarP(&outputFormat, "format", "f", "text", "output format: text, json, summary")
+	validateCmd.Flags().StringVarP(&minSeverity, "severity", "s", "warning", "minimum severity: error, warning, info")
+	rootCmd.AddCommand(validateCmd)
+}

--- a/pkg/validate/config.go
+++ b/pkg/validate/config.go
@@ -1,0 +1,33 @@
+package validate
+
+// Config holds validation configuration.
+type Config struct {
+	// ExcludeDirs are directory names to skip during vault traversal.
+	ExcludeDirs []string
+
+	// MinSeverity is the minimum severity level to report.
+	MinSeverity Severity
+}
+
+// DefaultConfig returns the default validation configuration.
+func DefaultConfig() Config {
+	return Config{
+		ExcludeDirs: DefaultExcludeDirs(),
+		MinSeverity: SeverityWarning,
+	}
+}
+
+// DefaultExcludeDirs returns the default directories to exclude from validation.
+func DefaultExcludeDirs() []string {
+	return []string{
+		".obsidian",
+		".trash",
+		".git",
+		"node_modules",
+	}
+}
+
+// ShouldReport returns true if the given severity meets the minimum threshold.
+func (c *Config) ShouldReport(s Severity) bool {
+	return SeverityOrder(s) <= SeverityOrder(c.MinSeverity)
+}

--- a/pkg/validate/result.go
+++ b/pkg/validate/result.go
@@ -1,0 +1,80 @@
+package validate
+
+import "encoding/json"
+
+// Severity represents the severity level of a validation finding.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// SeverityOrder returns the numeric order for severity (lower = more severe).
+func SeverityOrder(s Severity) int {
+	switch s {
+	case SeverityError:
+		return 0
+	case SeverityWarning:
+		return 1
+	case SeverityInfo:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// ValidationResult represents a single validation finding.
+type ValidationResult struct {
+	File       string   `json:"file"`
+	Severity   Severity `json:"severity"`
+	Rule       string   `json:"rule"`
+	Message    string   `json:"message"`
+	Suggestion string   `json:"suggestion,omitempty"`
+	Line       int      `json:"line,omitempty"`
+}
+
+// SeverityCounts holds the count of findings by severity.
+type SeverityCounts struct {
+	Errors   int `json:"errors"`
+	Warnings int `json:"warnings"`
+	Infos    int `json:"infos"`
+}
+
+// ValidationSummary is the top-level result of a vault validation.
+type ValidationSummary struct {
+	Vault      string             `json:"vault"`
+	TotalNotes int                `json:"totalNotes"`
+	Results    []ValidationResult `json:"results"`
+	Summary    SeverityCounts     `json:"summary"`
+}
+
+// HasErrors returns true if there are any error-severity findings.
+func (s *ValidationSummary) HasErrors() bool {
+	return s.Summary.Errors > 0
+}
+
+// ToJSON marshals the summary to indented JSON.
+func (s *ValidationSummary) ToJSON() (string, error) {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// ComputeSummary recalculates the severity counts from the results.
+func (s *ValidationSummary) ComputeSummary() {
+	s.Summary = SeverityCounts{}
+	for _, r := range s.Results {
+		switch r.Severity {
+		case SeverityError:
+			s.Summary.Errors++
+		case SeverityWarning:
+			s.Summary.Warnings++
+		case SeverityInfo:
+			s.Summary.Infos++
+		}
+	}
+}

--- a/pkg/validate/rules/frontmatter.go
+++ b/pkg/validate/rules/frontmatter.go
@@ -1,0 +1,159 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Yakitrak/notesmd-cli/pkg/frontmatter"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate"
+)
+
+// deprecatedSingularKeys maps deprecated singular keys to their correct plural forms.
+var deprecatedSingularKeys = map[string]string{
+	"tag":      "tags",
+	"alias":    "aliases",
+	"cssclass": "cssclasses",
+}
+
+// listTypeKeys are frontmatter keys that must be YAML lists, not strings.
+var listTypeKeys = []string{"tags", "aliases", "cssclasses"}
+
+// CheckFrontmatter runs all frontmatter validation rules on a note's content.
+// The filePath is used only for result reporting.
+func CheckFrontmatter(content, filePath string, config validate.Config) []validate.ValidationResult {
+	var results []validate.ValidationResult
+
+	// Rule: structure.empty-note — check before frontmatter rules
+	trimmed := strings.TrimSpace(content)
+	if len(trimmed) == 0 {
+		if config.ShouldReport(validate.SeverityWarning) {
+			results = append(results, validate.ValidationResult{
+				File:     filePath,
+				Severity: validate.SeverityWarning,
+				Rule:     "structure.empty-note",
+				Message:  "Note is empty",
+			})
+		}
+		return results
+	}
+
+	// Rule: frontmatter.missing
+	if !frontmatter.HasFrontmatter(content) {
+		if config.ShouldReport(validate.SeverityWarning) {
+			results = append(results, validate.ValidationResult{
+				File:     filePath,
+				Severity: validate.SeverityWarning,
+				Rule:     "frontmatter.missing",
+				Message:  "Note has no frontmatter",
+			})
+		}
+		return results
+	}
+
+	// Rule: frontmatter.parse-error
+	fm, _, err := frontmatter.Parse(content)
+	if err != nil {
+		if config.ShouldReport(validate.SeverityError) {
+			results = append(results, validate.ValidationResult{
+				File:     filePath,
+				Severity: validate.SeverityError,
+				Rule:     "frontmatter.parse-error",
+				Message:  "YAML frontmatter parse error",
+			})
+		}
+		return results
+	}
+
+	if fm == nil {
+		return results
+	}
+
+	// Rule: frontmatter.deprecated-singular
+	for singular, plural := range deprecatedSingularKeys {
+		if _, ok := fm[singular]; ok {
+			if config.ShouldReport(validate.SeverityWarning) {
+				results = append(results, validate.ValidationResult{
+					File:       filePath,
+					Severity:   validate.SeverityWarning,
+					Rule:       "frontmatter.deprecated-singular",
+					Message:    fmt.Sprintf("Deprecated property '%s' found", singular),
+					Suggestion: fmt.Sprintf("Use '%s' instead of '%s'", plural, singular),
+				})
+			}
+		}
+	}
+
+	// Rule: frontmatter.list-type
+	for _, key := range listTypeKeys {
+		val, ok := fm[key]
+		if !ok {
+			continue
+		}
+		if !isList(val) {
+			if config.ShouldReport(validate.SeverityError) {
+				results = append(results, validate.ValidationResult{
+					File:       filePath,
+					Severity:   validate.SeverityError,
+					Rule:       "frontmatter.list-type",
+					Message:    fmt.Sprintf("Property '%s' should be a list, not a scalar", key),
+					Suggestion: fmt.Sprintf("Change '%s: value' to '%s:\\n  - value'", key, key),
+				})
+			}
+		}
+	}
+
+	// Rule: frontmatter.tags-hash
+	if tags, ok := fm["tags"]; ok {
+		checkTagsForHash(tags, filePath, config, &results)
+	}
+
+	return results
+}
+
+// isList returns true if the value is a YAML list (Go slice).
+func isList(val interface{}) bool {
+	switch val.(type) {
+	case []interface{}:
+		return true
+	case []string:
+		return true
+	default:
+		return false
+	}
+}
+
+// checkTagsForHash checks if any tag in the tags list starts with '#'.
+func checkTagsForHash(tags interface{}, filePath string, config validate.Config, results *[]validate.ValidationResult) {
+	var tagStrings []string
+
+	switch v := tags.(type) {
+	case []interface{}:
+		for _, t := range v {
+			if s, ok := t.(string); ok {
+				tagStrings = append(tagStrings, s)
+			}
+		}
+	case []string:
+		tagStrings = v
+	case string:
+		// Single tag as string — also check for hash
+		tagStrings = []string{v}
+	default:
+		return
+	}
+
+	for _, tag := range tagStrings {
+		if strings.HasPrefix(tag, "#") {
+			if config.ShouldReport(validate.SeverityWarning) {
+				*results = append(*results, validate.ValidationResult{
+					File:       filePath,
+					Severity:   validate.SeverityWarning,
+					Rule:       "frontmatter.tags-hash",
+					Message:    fmt.Sprintf("Tag '%s' has '#' prefix in YAML frontmatter", tag),
+					Suggestion: "Remove '#' prefix from tags in frontmatter (Obsidian adds it automatically)",
+				})
+			}
+			return // Report once per file, not per tag
+		}
+	}
+}

--- a/pkg/validate/rules/frontmatter_test.go
+++ b/pkg/validate/rules/frontmatter_test.go
@@ -1,0 +1,175 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/Yakitrak/notesmd-cli/pkg/validate"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func defaultConfig() validate.Config {
+	return validate.DefaultConfig()
+}
+
+func TestCheckFrontmatter_EmptyNote(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+		rule    string
+	}{
+		{"empty string", "", 1, "structure.empty-note"},
+		{"whitespace only", "   \n\n  ", 1, "structure.empty-note"},
+		{"non-empty without frontmatter", "# Hello\nWorld", 1, "frontmatter.missing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rules.CheckFrontmatter(tt.content, "test.md", defaultConfig())
+			assert.Len(t, results, tt.want)
+			if tt.want > 0 {
+				assert.Equal(t, tt.rule, results[0].Rule)
+				assert.Equal(t, validate.SeverityWarning, results[0].Severity)
+			}
+		})
+	}
+}
+
+func TestCheckFrontmatter_Missing(t *testing.T) {
+	t.Run("note without frontmatter", func(t *testing.T) {
+		content := "# Title\n\nSome content"
+		results := rules.CheckFrontmatter(content, "test.md", defaultConfig())
+		assert.Len(t, results, 1)
+		assert.Equal(t, "frontmatter.missing", results[0].Rule)
+		assert.Equal(t, validate.SeverityWarning, results[0].Severity)
+	})
+
+	t.Run("note with frontmatter", func(t *testing.T) {
+		content := "---\ntitle: Test\n---\n# Title"
+		results := rules.CheckFrontmatter(content, "test.md", defaultConfig())
+		assert.Empty(t, results)
+	})
+}
+
+func TestCheckFrontmatter_ParseError(t *testing.T) {
+	t.Run("invalid YAML", func(t *testing.T) {
+		content := "---\ntitle: [invalid yaml\n---\n"
+		results := rules.CheckFrontmatter(content, "test.md", defaultConfig())
+		assert.Len(t, results, 1)
+		assert.Equal(t, "frontmatter.parse-error", results[0].Rule)
+		assert.Equal(t, validate.SeverityError, results[0].Severity)
+	})
+}
+
+func TestCheckFrontmatter_DeprecatedSingular(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"tags is valid", "---\ntags:\n  - go\n---\n", 0},
+		{"tag triggers warning", "---\ntag: go\n---\n", 1},
+		{"alias triggers warning", "---\nalias: test\n---\n", 1},
+		{"cssclass triggers warning", "---\ncssclass: wide\n---\n", 1},
+		{"aliases is valid", "---\naliases:\n  - test\n---\n", 0},
+		{"cssclasses is valid", "---\ncssclasses:\n  - wide\n---\n", 0},
+		{"both tag and alias trigger warnings", "---\ntag: go\nalias: test\n---\n", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rules.CheckFrontmatter(tt.content, "test.md", defaultConfig())
+			deprecatedResults := filterByRule(results, "frontmatter.deprecated-singular")
+			assert.Len(t, deprecatedResults, tt.want)
+			for _, r := range deprecatedResults {
+				assert.Equal(t, validate.SeverityWarning, r.Severity)
+				assert.NotEmpty(t, r.Suggestion)
+			}
+		})
+	}
+}
+
+func TestCheckFrontmatter_ListType(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"tags as list is valid", "---\ntags:\n  - go\n  - cli\n---\n", 0},
+		{"tags as string is error", "---\ntags: go\n---\n", 1},
+		{"aliases as string is error", "---\naliases: test\n---\n", 1},
+		{"cssclasses as string is error", "---\ncssclasses: wide\n---\n", 1},
+		{"missing key is ok", "---\ntitle: Test\n---\n", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rules.CheckFrontmatter(tt.content, "test.md", defaultConfig())
+			listResults := filterByRule(results, "frontmatter.list-type")
+			assert.Len(t, listResults, tt.want)
+			for _, r := range listResults {
+				assert.Equal(t, validate.SeverityError, r.Severity)
+			}
+		})
+	}
+}
+
+func TestCheckFrontmatter_TagsHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"tags without hash", "---\ntags:\n  - go\n  - cli\n---\n", 0},
+		{"tags with hash prefix", "---\ntags:\n  - \"#go\"\n  - cli\n---\n", 1},
+		{"single tag string with hash", "---\ntags: \"#go\"\n---\n", 1}, // tags as string also triggers hash check
+		{"no tags key", "---\ntitle: Test\n---\n", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rules.CheckFrontmatter(tt.content, "test.md", defaultConfig())
+			hashResults := filterByRule(results, "frontmatter.tags-hash")
+			assert.Len(t, hashResults, tt.want)
+		})
+	}
+}
+
+func TestCheckFrontmatter_SeverityFilter(t *testing.T) {
+	t.Run("error-only severity skips warnings", func(t *testing.T) {
+		content := "---\ntag: go\n---\n" // deprecated-singular is a warning
+		config := validate.Config{
+			ExcludeDirs: validate.DefaultExcludeDirs(),
+			MinSeverity: validate.SeverityError,
+		}
+		results := rules.CheckFrontmatter(content, "test.md", config)
+		assert.Empty(t, results)
+	})
+
+	t.Run("error severity reports parse errors", func(t *testing.T) {
+		content := "---\ntitle: [broken\n---\n"
+		config := validate.Config{
+			ExcludeDirs: validate.DefaultExcludeDirs(),
+			MinSeverity: validate.SeverityError,
+		}
+		results := rules.CheckFrontmatter(content, "test.md", config)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "frontmatter.parse-error", results[0].Rule)
+	})
+}
+
+func TestCheckFrontmatter_FilePathInResults(t *testing.T) {
+	t.Run("file path is preserved in results", func(t *testing.T) {
+		content := "# No frontmatter"
+		results := rules.CheckFrontmatter(content, "daily/2024-01-15.md", defaultConfig())
+		assert.Len(t, results, 1)
+		assert.Equal(t, "daily/2024-01-15.md", results[0].File)
+	})
+}
+
+func filterByRule(results []validate.ValidationResult, rule string) []validate.ValidationResult {
+	var filtered []validate.ValidationResult
+	for _, r := range results {
+		if r.Rule == rule {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}

--- a/pkg/validate/rules/structure.go
+++ b/pkg/validate/rules/structure.go
@@ -1,0 +1,87 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Yakitrak/notesmd-cli/pkg/validate"
+)
+
+// CheckStructure runs structural validation rules on note content.
+// The filePath is used only for result reporting.
+func CheckStructure(content, filePath string, config validate.Config) []validate.ValidationResult {
+	var results []validate.ValidationResult
+
+	// Rule: structure.heading-hierarchy
+	results = append(results, checkHeadingHierarchy(content, filePath, config)...)
+
+	return results
+}
+
+// checkHeadingHierarchy detects skipped heading levels (e.g. H1 -> H3 without H2).
+func checkHeadingHierarchy(content, filePath string, config validate.Config) []validate.ValidationResult {
+	if !config.ShouldReport(validate.SeverityWarning) {
+		return nil
+	}
+
+	var results []validate.ValidationResult
+	lines := strings.Split(content, "\n")
+	lastLevel := 0
+	inFrontmatter := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip frontmatter block
+		if trimmed == "---" {
+			inFrontmatter = !inFrontmatter
+			continue
+		}
+		if inFrontmatter {
+			continue
+		}
+
+		// Skip code blocks
+		if strings.HasPrefix(trimmed, "```") {
+			continue
+		}
+
+		// Detect ATX headings (# H1, ## H2, etc.)
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		level := 0
+		for _, ch := range trimmed {
+			if ch == '#' {
+				level++
+			} else {
+				break
+			}
+		}
+
+		// Must have a space after the hashes to be a valid heading
+		if level >= len(trimmed) || trimmed[level] != ' ' {
+			continue
+		}
+
+		if level < 1 || level > 6 {
+			continue
+		}
+
+		if lastLevel > 0 && level > lastLevel+1 {
+			results = append(results, validate.ValidationResult{
+				File:       filePath,
+				Severity:   validate.SeverityWarning,
+				Rule:       "structure.heading-hierarchy",
+				Message:    fmt.Sprintf("Heading level skipped: H%d to H%d", lastLevel, level),
+				Suggestion: fmt.Sprintf("Add an H%d heading before this H%d", lastLevel+1, level),
+				Line:       i + 1,
+			})
+		}
+
+		lastLevel = level
+	}
+
+	return results
+}

--- a/pkg/validate/rules/structure_test.go
+++ b/pkg/validate/rules/structure_test.go
@@ -1,0 +1,95 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/Yakitrak/notesmd-cli/pkg/validate"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckStructure_HeadingHierarchy(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			"valid hierarchy H1 H2 H3",
+			"# Title\n## Section\n### Subsection\n",
+			0,
+		},
+		{
+			"skipped level H1 to H3",
+			"# Title\n### Subsection\n",
+			1,
+		},
+		{
+			"skipped level H2 to H4",
+			"## Section\n#### Deep\n",
+			1,
+		},
+		{
+			"multiple skips",
+			"# Title\n### Skip1\n##### Skip2\n",
+			2,
+		},
+		{
+			"no headings",
+			"Just some text\nMore text\n",
+			0,
+		},
+		{
+			"heading without space is not a heading",
+			"#notaheading\n## Real heading\n",
+			0,
+		},
+		{
+			"frontmatter is ignored",
+			"---\ntitle: Test\n---\n# Title\n## Section\n",
+			0,
+		},
+		{
+			"going down then back up is valid",
+			"# Title\n## Section\n### Sub\n## Another Section\n",
+			0,
+		},
+		{
+			"H2 then H3 is valid even without H1",
+			"## Section\n### Subsection\n",
+			0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rules.CheckStructure(tt.content, "test.md", defaultConfig())
+			headingResults := filterByRule(results, "structure.heading-hierarchy")
+			assert.Len(t, headingResults, tt.want)
+			for _, r := range headingResults {
+				assert.Equal(t, validate.SeverityWarning, r.Severity)
+				assert.Greater(t, r.Line, 0)
+			}
+		})
+	}
+}
+
+func TestCheckStructure_HeadingHierarchyLineNumbers(t *testing.T) {
+	t.Run("reports correct line number", func(t *testing.T) {
+		content := "# Title\nSome text\n### Skipped H3\n"
+		results := rules.CheckStructure(content, "test.md", defaultConfig())
+		assert.Len(t, results, 1)
+		assert.Equal(t, 3, results[0].Line)
+	})
+}
+
+func TestCheckStructure_SeverityFilter(t *testing.T) {
+	t.Run("error-only severity skips heading warnings", func(t *testing.T) {
+		content := "# Title\n### Skipped\n"
+		config := validate.Config{
+			ExcludeDirs: validate.DefaultExcludeDirs(),
+			MinSeverity: validate.SeverityError,
+		}
+		results := rules.CheckStructure(content, "test.md", config)
+		assert.Empty(t, results)
+	})
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -1,0 +1,126 @@
+package validate
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Yakitrak/notesmd-cli/pkg/obsidian"
+)
+
+// RuleFunc is a function that checks a note and returns validation results.
+type RuleFunc func(content, filePath string, config Config) []ValidationResult
+
+// ValidateVault walks a vault directory, validates all markdown notes, and returns a summary.
+func ValidateVault(vault obsidian.VaultManager, config Config, rules []RuleFunc) (*ValidationSummary, error) {
+	vaultName, err := vault.DefaultName()
+	if err != nil {
+		return nil, err
+	}
+
+	vaultPath, err := vault.Path()
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &ValidationSummary{
+		Vault: vaultName,
+	}
+
+	excludeSet := make(map[string]bool, len(config.ExcludeDirs))
+	for _, dir := range config.ExcludeDirs {
+		excludeSet[dir] = true
+	}
+
+	err = filepath.WalkDir(vaultPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil // Skip inaccessible paths
+		}
+
+		// Skip excluded directories
+		if d.IsDir() {
+			if excludeSet[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only process .md files
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+
+		summary.TotalNotes++
+
+		relPath, err := filepath.Rel(vaultPath, path)
+		if err != nil {
+			relPath = path
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			// Report unreadable files as errors
+			if config.ShouldReport(SeverityError) {
+				summary.Results = append(summary.Results, ValidationResult{
+					File:     relPath,
+					Severity: SeverityError,
+					Rule:     "file.unreadable",
+					Message:  "Could not read file",
+				})
+			}
+			return nil
+		}
+
+		// Run all rules on this note
+		for _, rule := range rules {
+			results := rule(string(content), relPath, config)
+			summary.Results = append(summary.Results, results...)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	summary.ComputeSummary()
+	return summary, nil
+}
+
+// ValidatePath validates a single note at the given path within the vault.
+func ValidatePath(vault obsidian.VaultManager, notePath string, config Config, rules []RuleFunc) (*ValidationSummary, error) {
+	vaultName, err := vault.DefaultName()
+	if err != nil {
+		return nil, err
+	}
+
+	vaultPath, err := vault.Path()
+	if err != nil {
+		return nil, err
+	}
+
+	fullPath := filepath.Join(vaultPath, notePath)
+	if !strings.HasSuffix(fullPath, ".md") {
+		fullPath += ".md"
+	}
+
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &ValidationSummary{
+		Vault:      vaultName,
+		TotalNotes: 1,
+	}
+
+	for _, rule := range rules {
+		results := rule(string(content), notePath, config)
+		summary.Results = append(summary.Results, results...)
+	}
+
+	summary.ComputeSummary()
+	return summary, nil
+}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -1,0 +1,200 @@
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Yakitrak/notesmd-cli/mocks"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate"
+	"github.com/Yakitrak/notesmd-cli/pkg/validate/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func allRules() []validate.RuleFunc {
+	return []validate.RuleFunc{
+		rules.CheckFrontmatter,
+		rules.CheckStructure,
+	}
+}
+
+func createNote(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(path, []byte(content), 0644)
+	assert.NoError(t, err)
+}
+
+func TestValidateVault_Integration(t *testing.T) {
+	t.Run("mixed vault with valid and invalid notes", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		vault := &mocks.MockVaultOperator{Name: "TestVault", PathValue: tmpDir}
+
+		// Good note - valid frontmatter
+		createNote(t, tmpDir, "good.md", "---\ntitle: Good Note\ntags:\n  - go\n---\n# Good Note\n\nContent here.\n")
+
+		// Bad YAML - parse error
+		createNote(t, tmpDir, "bad-yaml.md", "---\ntitle: [broken yaml\n---\n")
+
+		// Deprecated property
+		createNote(t, tmpDir, "deprecated.md", "---\ntag: oldstyle\n---\n# Note\n")
+
+		// Empty note
+		createNote(t, tmpDir, "empty.md", "")
+
+		// Obsidian config dir - should be skipped
+		createNote(t, tmpDir, ".obsidian/app.json", `{"key": "value"}`)
+
+		// Trash dir - should be skipped
+		createNote(t, tmpDir, ".trash/deleted.md", "---\ntitle: Deleted\n---\n")
+
+		config := validate.DefaultConfig()
+		summary, err := validate.ValidateVault(vault, config, allRules())
+		assert.NoError(t, err)
+
+		// Should count 4 notes (not .obsidian/app.json or .trash/deleted.md)
+		assert.Equal(t, 4, summary.TotalNotes)
+		assert.Equal(t, "TestVault", summary.Vault)
+
+		// Should have findings
+		assert.True(t, summary.HasErrors(), "should have errors from bad-yaml.md")
+		assert.Greater(t, summary.Summary.Warnings, 0, "should have warnings")
+
+		// Verify specific rules were triggered
+		ruleMap := make(map[string]int)
+		for _, r := range summary.Results {
+			ruleMap[r.Rule]++
+		}
+
+		assert.Equal(t, 1, ruleMap["frontmatter.parse-error"], "bad YAML should trigger parse error")
+		assert.Equal(t, 1, ruleMap["structure.empty-note"], "empty note should be detected")
+		assert.Equal(t, 1, ruleMap["frontmatter.deprecated-singular"], "deprecated tag should be detected")
+	})
+
+	t.Run("vault with only valid notes", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		vault := &mocks.MockVaultOperator{Name: "CleanVault", PathValue: tmpDir}
+
+		createNote(t, tmpDir, "note1.md", "---\ntitle: Note 1\ntags:\n  - test\n---\n# Note 1\n\nContent.\n")
+		createNote(t, tmpDir, "note2.md", "---\ntitle: Note 2\n---\n## Section\n\nMore content.\n")
+
+		config := validate.DefaultConfig()
+		summary, err := validate.ValidateVault(vault, config, allRules())
+		assert.NoError(t, err)
+		assert.Equal(t, 2, summary.TotalNotes)
+		assert.Empty(t, summary.Results)
+		assert.False(t, summary.HasErrors())
+	})
+
+	t.Run("empty vault", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		vault := &mocks.MockVaultOperator{Name: "EmptyVault", PathValue: tmpDir}
+
+		config := validate.DefaultConfig()
+		summary, err := validate.ValidateVault(vault, config, allRules())
+		assert.NoError(t, err)
+		assert.Equal(t, 0, summary.TotalNotes)
+		assert.Empty(t, summary.Results)
+	})
+
+	t.Run("vault path error", func(t *testing.T) {
+		vault := &mocks.MockVaultOperator{
+			Name:      "BadVault",
+			PathError: assert.AnError,
+		}
+
+		config := validate.DefaultConfig()
+		_, err := validate.ValidateVault(vault, config, allRules())
+		assert.Error(t, err)
+	})
+}
+
+func TestValidatePath_Integration(t *testing.T) {
+	t.Run("validate single note", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		vault := &mocks.MockVaultOperator{Name: "TestVault", PathValue: tmpDir}
+
+		createNote(t, tmpDir, "daily/2024-01-15.md", "---\ntag: daily\n---\n# January 15\n")
+
+		config := validate.DefaultConfig()
+		summary, err := validate.ValidatePath(vault, "daily/2024-01-15.md", config, allRules())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, summary.TotalNotes)
+
+		deprecatedResults := filterByRule(summary.Results, "frontmatter.deprecated-singular")
+		assert.Len(t, deprecatedResults, 1)
+	})
+
+	t.Run("validate note without .md extension", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		vault := &mocks.MockVaultOperator{Name: "TestVault", PathValue: tmpDir}
+
+		createNote(t, tmpDir, "note.md", "---\ntitle: Test\n---\n# Note\n")
+
+		config := validate.DefaultConfig()
+		summary, err := validate.ValidatePath(vault, "note", config, allRules())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, summary.TotalNotes)
+		assert.Empty(t, summary.Results)
+	})
+}
+
+func TestValidationSummary_JSON(t *testing.T) {
+	t.Run("JSON output is valid", func(t *testing.T) {
+		summary := &validate.ValidationSummary{
+			Vault:      "TestVault",
+			TotalNotes: 10,
+			Results: []validate.ValidationResult{
+				{
+					File:     "test.md",
+					Severity: validate.SeverityError,
+					Rule:     "frontmatter.parse-error",
+					Message:  "YAML parse error",
+				},
+			},
+		}
+		summary.ComputeSummary()
+
+		jsonStr, err := summary.ToJSON()
+		assert.NoError(t, err)
+		assert.Contains(t, jsonStr, `"vault": "TestVault"`)
+		assert.Contains(t, jsonStr, `"frontmatter.parse-error"`)
+	})
+}
+
+func TestConfig_ShouldReport(t *testing.T) {
+	tests := []struct {
+		name        string
+		minSeverity validate.Severity
+		check       validate.Severity
+		expected    bool
+	}{
+		{"error reports error", validate.SeverityError, validate.SeverityError, true},
+		{"error skips warning", validate.SeverityError, validate.SeverityWarning, false},
+		{"error skips info", validate.SeverityError, validate.SeverityInfo, false},
+		{"warning reports error", validate.SeverityWarning, validate.SeverityError, true},
+		{"warning reports warning", validate.SeverityWarning, validate.SeverityWarning, true},
+		{"warning skips info", validate.SeverityWarning, validate.SeverityInfo, false},
+		{"info reports everything", validate.SeverityInfo, validate.SeverityError, true},
+		{"info reports warning", validate.SeverityInfo, validate.SeverityWarning, true},
+		{"info reports info", validate.SeverityInfo, validate.SeverityInfo, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := validate.Config{MinSeverity: tt.minSeverity}
+			assert.Equal(t, tt.expected, config.ShouldReport(tt.check))
+		})
+	}
+}
+
+func filterByRule(results []validate.ValidationResult, rule string) []validate.ValidationResult {
+	var filtered []validate.ValidationResult
+	for _, r := range results {
+		if r.Rule == rule {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
## Summary

Add a new `validate` command that checks Obsidian vault notes for common quality issues.

### Usage

```bash
# Validate entire vault
notesmd-cli validate --vault MyVault

# Validate a single note
notesmd-cli validate daily/2024-01-15 --vault MyVault

# JSON output
notesmd-cli validate --vault MyVault -f json

# Errors only
notesmd-cli validate --vault MyVault -s error
```

### Rules implemented

| Rule ID | Severity | Description |
|---------|----------|-------------|
| `frontmatter.parse-error` | error | Invalid YAML frontmatter |
| `frontmatter.missing` | warning | Note without frontmatter |
| `frontmatter.deprecated-singular` | warning | `tag`/`alias`/`cssclass` should be `tags`/`aliases`/`cssclasses` |
| `frontmatter.list-type` | error | `tags`/`aliases`/`cssclasses` must be lists |
| `frontmatter.tags-hash` | warning | Tags with `#` prefix in YAML |
| `structure.empty-note` | warning | Empty or whitespace-only note |
| `structure.heading-hierarchy` | warning | Skipped heading levels (e.g. H1 to H3) |

### Flags

| Flag | Short | Default | Description |
|------|-------|---------|-------------|
| `--vault` | `-v` | `""` | Vault name |
| `--format` | `-f` | `text` | Output: `text`, `json`, `summary` |
| `--severity` | `-s` | `warning` | Minimum severity: `error`, `warning`, `info` |

### Architecture

- `cmd/validate.go` — Cobra command (registered via `init()`)
- `pkg/validate/result.go` — Types (ValidationResult, Severity, Summary)
- `pkg/validate/config.go` — Default config and directory exclusions
- `pkg/validate/validate.go` — Orchestrator (walk vault, collect results)
- `pkg/validate/rules/frontmatter.go` — 5 frontmatter rules
- `pkg/validate/rules/structure.go` — 2 structure rules

Reuses existing patterns: `VaultManager` interface, `frontmatter.Parse()`, `filepath.WalkDir`, mock pattern from `mocks/vault.go`.

Exit code 1 when errors are found (useful for CI).

## Checklist

- [x] I have written unit tests for my changes
- [ ] I have updated the documentation accordingly
- [x] All tests pass (`go test ./...`)
