### PR TITLE
feat: add Nix flake support and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,80 @@ Or build from source:
 yay -S notesmd-cli
 ```
 
+### Nix / NixOS
+
+The package is **not** in Nixpkgs as of this writing. You can install it with the **flake in this repo** (see below), or using the `buildGoModule` in **NixOS / Home Manager**, or by reusing the package from this flake inside your own.
+
+#### Nix Flake
+
+The repo includes `flake.nix` at the root. `flake.lock` pins revs to ensure reproducibility. You can use the package in various ways:
+
+
+- **Run the CLI directly** - use `--` so flags go to `notesmd-cli`, not Nix:
+
+  ```bash
+  nix run github:Yakitrak/notesmd-cli -- --help
+  nix run github:Yakitrak/notesmd-cli -- list-vaults
+  ```
+
+- Or clone the repo, and then run it:
+
+  ```bash
+  nix run .# -- --help
+  ```
+
+- Or build and use the binary from `./result`:
+
+  ```bash
+  nix build github:Yakitrak/notesmd-cli
+  ./result/bin/notesmd-cli --help
+  ```
+
+- Or enter an ephemeral shell with updated `$PATH`:
+
+  ```bash
+  nix develop github:Yakitrak/notesmd-cli
+  notesmd-cli --help
+  exit
+  ```
+
+You can **pin a release** by adding a ref to the flake URL (tag, branch, or commit: `github:OWNER/REPO/REF`), for example:
+
+```bash
+nix run github:Yakitrak/notesmd-cli/v0.3.4 -- --help
+```
+
+#### NixOS (`configuration.nix`)
+
+Add a package to `environment.systemPackages` (or use `home.packages` on Home Manager the same way). `fetchFromGitHub.rev` should match the exact commit you want:
+
+```nix
+{ pkgs, lib, ... }:
+
+{ # ...
+  environment.systemPackages = [
+    (pkgs.buildGoModule {
+      pname = "notesmd-cli";
+      version = "0.3.4";
+
+      src = pkgs.fetchFromGitHub {
+        owner = "Yakitrak";
+        repo = "notesmd-cli";
+        rev = "b58227d0ffaa06eb7880ba7cd16561111deda79d"; # commit for v0.3.4
+        hash = "sha256-sZKyXDgDuJI7cFIMQl1w2Ir92HmhZ1Vhz7FUoEkn3Mo="; # hash for v0.3.4
+      };
+      vendorHash = null;
+    })
+  ];
+  # ...
+}
+```
+
+**Updating**: When you change `rev`, you must update `hash` as well, otherwise the build fails. To obtain the 
+correct `hash`, temporarily set `hash = lib.fakeHash;` and run `sudo nixos-rebuild switch`, copy 
+the `sha256-...` value from the error message into your configuration, and rebuild again.
+
+
 ### Build from Source
 
 Requires [Go](https://go.dev/dl/) 1.19 or later.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "NotesMD CLI — terminal tool for Markdown / Obsidian-style vaults";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      version =
+        self.shortRev or self.dirtyShortRev or "0.0.0+${self.lastModifiedDate}";
+    in
+    {
+      packages = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.buildGoModule {
+            pname = "notesmd-cli";
+            inherit version;
+            src = ./.;
+            vendorHash = null;
+            meta = {
+              mainProgram = "notesmd-cli";
+              description = "CLI for Obsidian-style Markdown vaults without requiring Obsidian";
+              homepage = "https://github.com/Yakitrak/notesmd-cli";
+              license = pkgs.lib.licenses.mit;
+            };
+          };
+        });
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/notesmd-cli";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.mkShell {
+            packages = [ self.packages.${system}.default ];
+          };
+        });
+    };
+}


### PR DESCRIPTION

## Nix Flake support + Installation/Run instructions for Nix users

**Description**

Installation instructions for Nix/NixOS users.
Add a repo-root flake (`flake.nix`, `flake.lock`) that allows Nix users to run/build the package directly with e.g.
`nix run github:Yakitrak/notesmd-cli -- list-vaults`
or also easily build the binary, or use the package in a shell, as per instructions.
Also supports future versions with e.g. `nix run github:Yakitrak/notesmd-cli/v0.3.5 -- --help`

**Motivation and Context**

There is no Nixpkgs package yet for this repo; the flake gives Nix users a simple command to use the package, and `flake.lock` ensures future reproducibility. Also, installation instructions for non-flake Nix users.

**Checklist:**

- [x] I have written unit tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.